### PR TITLE
Add selectable auto pilot strategies with toggle indicator

### DIFF
--- a/old/mine.html
+++ b/old/mine.html
@@ -76,6 +76,86 @@
     .actions {
       display: flex;
       gap: 8px;
+      align-items: center;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+    .auto-controls {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      justify-content: center;
+      padding: 6px 10px;
+      border-radius: 8px;
+      border: 1px solid rgba(59, 130, 246, 0.2);
+      background: rgba(37, 99, 235, 0.08);
+    }
+    .auto-controls label {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #1d4ed8;
+    }
+    #autoStrategy {
+      appearance: none;
+      border: 1px solid rgba(37, 99, 235, 0.35);
+      border-radius: 6px;
+      padding: 6px 28px 6px 10px;
+      font-weight: 600;
+      min-width: 160px;
+      background-color: #fff;
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8" fill="none"><path d="M1 1.5L6 6.5L11 1.5" stroke="%233b82f6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+      background-repeat: no-repeat;
+      background-position: right 8px center;
+      background-size: 12px 8px;
+      color: #1e3a8a;
+      cursor: pointer;
+    }
+    #autoStrategy:focus {
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
+    }
+    #autoStrategy:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+    .auto-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: #e2e8f0;
+      color: #475569;
+      font-weight: 600;
+      font-size: 0.85rem;
+      transition: background-color 0.2s ease, color 0.2s ease;
+    }
+    .auto-indicator .auto-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: #94a3b8;
+      box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.35);
+      transition: background-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .auto-indicator[data-state='on'] {
+      background: rgba(34, 197, 94, 0.15);
+      color: #15803d;
+    }
+    .auto-indicator[data-state='on'] .auto-dot {
+      background: #22c55e;
+      box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.3);
+    }
+    .auto-indicator[data-state='stopping'] {
+      background: rgba(249, 115, 22, 0.18);
+      color: #c2410c;
+    }
+    .auto-indicator[data-state='stopping'] .auto-dot {
+      background: #f97316;
+      box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.28);
     }
     .status-panel {
       text-align: center;
@@ -196,6 +276,17 @@
         <button data-difficulty="expert">Expert</button>
       </div>
       <div class="actions">
+        <div class="auto-controls">
+          <label for="autoStrategy">AI Brain</label>
+          <select id="autoStrategy" aria-label="Choose an auto pilot strategy">
+            <option value="solver">Constraint Solver</option>
+            <option value="random">Random Explorer</option>
+          </select>
+          <span id="autoIndicator" class="auto-indicator" data-state="off">
+            <span class="auto-dot"></span>
+            <span class="auto-text">Auto Pilot Off</span>
+          </span>
+        </div>
         <button id="autoButton" title="Let the AI take the wheel">Auto Pilot</button>
       </div>
     </div>

--- a/old/minesweeper/scripts/ui.js
+++ b/old/minesweeper/scripts/ui.js
@@ -400,11 +400,17 @@ export class MinesweeperUI {
     if (this.autoRunning) {
       return;
     }
+    const shouldResetForAuto =
+      !this.game ||
+      this.game.status === GameStatus.LOST ||
+      this.game.status === GameStatus.WON;
+    if (shouldResetForAuto) {
+      this._selectDifficulty(this.currentDifficultyKey, { preserveAuto: true });
+    }
     this.mode = 'auto';
     this.autoRunning = true;
     this.autoAbort = false;
     this.autoStopping = false;
-    this._selectDifficulty(this.currentDifficultyKey, { preserveAuto: true });
     const strategyKey = this._getSelectedStrategyKey();
     const strategy = this._getStrategyConfig(strategyKey);
     this._setStatus(`Auto pilot engaged with ${strategy.label}. Watching the magic happen.`);

--- a/tests/autoPlayer.test.js
+++ b/tests/autoPlayer.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { MinesweeperGame, GameStatus, MINE } from '../old/minesweeper/scripts/game.js';
-import { AutoPlayer, applyAutoAction } from '../old/minesweeper/scripts/autoPlayer.js';
+import { AutoPlayer, RandomAutoPlayer, applyAutoAction } from '../old/minesweeper/scripts/autoPlayer.js';
 
 const layout = [
   [MINE, 1, 0, 1, MINE],
@@ -20,4 +20,14 @@ test('auto player can cruise through a handcrafted board', async () => {
     applyAutoAction(game, action);
   });
   assert.equal(game.status, GameStatus.WON);
+});
+
+test('random auto player finishes the simplest safe board without flagging', async () => {
+  const game = new MinesweeperGame(1, 1, 0);
+  const auto = new RandomAutoPlayer(game, { delayMs: 0, rng: () => 0 });
+  await auto.play(async action => {
+    applyAutoAction(game, action);
+  });
+  assert.equal(game.status, GameStatus.WON);
+  assert.equal(game.flagged[0][0], false);
 });


### PR DESCRIPTION
## Summary
- add a strategy picker and status indicator to the auto pilot controls so it can be toggled on and off
- extend the UI logic to honour the selected strategy, expose a random explorer AI, and update the auto player state handling
- introduce a RandomAutoPlayer implementation with accompanying tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd63a414688322b9fd8e77f78b0eb2