### PR TITLE
Add navigation links back to index on archived pages

### DIFF
--- a/old/index.html
+++ b/old/index.html
@@ -27,11 +27,24 @@ img.displayed {
   margin-right:auto;
 }
 .gameSpace {
-	width : 480px;
-	background-color: white;
-	padding-top : 10px;
+        width : 480px;
+        background-color: white;
+        padding-top : 10px;
   margin-left:auto;
   margin-right:auto;
+}
+.back-link {
+  text-align: center;
+  margin-bottom: 12px;
+}
+.back-link a {
+  color: #00a;
+  font-weight: bold;
+  text-decoration: none;
+}
+.back-link a:hover,
+.back-link a:focus {
+  text-decoration: underline;
 }
 p {
   text-align : center;
@@ -47,6 +60,8 @@ div#difficultity {
 <body>
 
 <div class="gameSpace">
+
+<p class="back-link"><a href="../index.html">&larr; Back to site index</a></p>
 
 <center>
 

--- a/old/jumble.html
+++ b/old/jumble.html
@@ -111,36 +111,51 @@ function transformWord(inWord) {
 <style>
 body {
     background-color: #d0e4fe;
-	padding-top : 10px
+        padding-top : 10px
 }
 h1 {
-	text-decoration: underline;
-	font-size : 15px;
+        text-decoration: underline;
+        font-size : 15px;
     text-align: center;
 }
 p {
     text-align: center;
 }
 .mainDiv {
-	width : 400px;
-	background-color: white;
-	padding : 10px;
+        width : 400px;
+        background-color: white;
+        padding : 10px;
     margin-left:auto;
-    margin-right:auto; 
+    margin-right:auto;
+}
+.back-link {
+    text-align: center;
+    margin-bottom: 12px;
+}
+.back-link a {
+    color: #00a;
+    font-weight: bold;
+    text-decoration: none;
+}
+.back-link a:hover,
+.back-link a:focus {
+    text-decoration: underline;
 }
 .mainOut {
-	font-size: 20px;
-	color: #00a;
-	text-align : center;
+        font-size: 20px;
+        color: #00a;
+        text-align : center;
 }
 </style>
 </head>
 
 <body onload="clearField()">
-	
+
 <div class="mainDiv">
-	
-	<h1>Type a word to see if this page can unscramble it!</h1>
+
+        <p class="back-link"><a href="../index.html">&larr; Back to site index</a></p>
+
+        <h1>Type a word to see if this page can unscramble it!</h1>
 	<p><input type="text" id="userWord" onkeyup="closestWord()" value=""/></p>
 	<p>Unscrambling attempt: </p>
 	<div id="showIt" class="mainOut"></div>

--- a/old/mine.html
+++ b/old/mine.html
@@ -33,6 +33,19 @@
       border-radius: 12px;
       box-shadow: 0 6px 30px rgba(15, 23, 42, 0.2);
     }
+    .back-link {
+      text-align: center;
+      margin-bottom: 16px;
+    }
+    .back-link a {
+      color: #2563eb;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .back-link a:hover,
+    .back-link a:focus {
+      text-decoration: underline;
+    }
     .controls {
       display: flex;
       flex-wrap: wrap;
@@ -268,6 +281,7 @@
 </head>
 <body>
   <div class="gameSpace">
+    <p class="back-link"><a href="../index.html">&larr; Back to site index</a></p>
     <h1 align="center">Land Mine Mapper v0.2</h1>
     <div class="controls">
       <div class="difficulty">


### PR DESCRIPTION
## Summary
- add a styled navigation link back to the main index on the Minesweeper page
- provide the same link on the archived index and Word Jumble pages for consistent navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd69129c648322adf9db6ec0d80100