### PR TITLE
Revamp leaderboard with mode/difficulty splits and stats

### DIFF
--- a/old/mine.html
+++ b/old/mine.html
@@ -246,29 +246,89 @@
       opacity: 0;
       cursor: pointer;
     }
-    .score-lists {
+    .score-groups {
       display: flex;
       flex-direction: column;
-      gap: 16px;
+      gap: 18px;
     }
-    .score-column h2 {
-      margin: 0 0 6px;
-      font-size: 1.1rem;
+    .mode-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
     }
-    .score-column ol {
+    .mode-section > h2 {
+      margin: 0;
+      font-size: 1.2rem;
+      color: #0f172a;
+    }
+    .difficulty-board {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 12px;
+      border: 1px solid rgba(15, 23, 42, 0.1);
+      border-radius: 10px;
+      background: rgba(226, 232, 240, 0.4);
+    }
+    .board-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .board-header h3 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+    .clear-leaderboard {
+      padding: 4px 10px;
+      font-size: 0.85rem;
+      border: 1px solid rgba(148, 163, 184, 0.6);
+      border-radius: 999px;
+      background: rgba(241, 245, 249, 0.85);
+      color: #0f172a;
+      cursor: pointer;
+    }
+    .clear-leaderboard:hover {
+      background: rgba(226, 232, 240, 1);
+    }
+    .board-stats {
+      font-size: 0.9rem;
+      color: #475569;
+    }
+    .score-list {
       margin: 0;
       padding-left: 20px;
     }
-    .score-column li {
+    .score-list li {
       margin-bottom: 4px;
+      font-size: 0.95rem;
     }
-    @media (min-width: 520px) {
-      .score-lists {
+    .score-list .empty-state {
+      list-style: none;
+      padding-left: 0;
+      color: #64748b;
+      font-style: italic;
+    }
+    .score-time {
+      font-weight: 600;
+      color: #0f172a;
+    }
+    .score-recorded {
+      color: #64748b;
+    }
+    @media (min-width: 720px) {
+      .mode-section {
         flex-direction: row;
-        justify-content: space-between;
+        align-items: flex-start;
+        flex-wrap: wrap;
+        gap: 16px;
       }
-      .score-column {
-        flex: 1;
+      .mode-section > h2 {
+        flex: 1 1 100%;
+      }
+      .difficulty-board {
+        flex: 1 1 220px;
       }
     }
     .copyright {
@@ -287,7 +347,7 @@
       <div class="difficulty">
         <button data-difficulty="beginner" class="active">Beginner</button>
         <button data-difficulty="intermediate">Intermediate</button>
-        <button data-difficulty="expert">Expert</button>
+        <button data-difficulty="expert">Advanced</button>
       </div>
       <div class="actions">
         <div class="auto-controls">
@@ -323,16 +383,7 @@
           <input type="file" id="importScores" accept="application/json">
         </label>
       </div>
-      <div class="score-lists">
-        <div class="score-column">
-          <h2>Player Leaderboard</h2>
-          <ol id="playerScores"></ol>
-        </div>
-        <div class="score-column">
-          <h2>Auto Leaderboard</h2>
-          <ol id="autoScores"></ol>
-        </div>
-      </div>
+      <div id="leaderboardContainer" class="score-groups"></div>
     </div>
     <div class="copyright">
       <p>Game originally produced by Alan Rominger, 2015, now tuned up with modern JavaScript flair.</p>

--- a/old/minesweeper/scripts/scoreboard.js
+++ b/old/minesweeper/scripts/scoreboard.js
@@ -1,4 +1,6 @@
 const STORAGE_KEY = 'minesweeper_scores_v2';
+const STORAGE_VERSION = 3;
+const MODES = ['human', 'auto'];
 
 const defaultStorage = (() => {
   if (typeof window !== 'undefined' && window.localStorage) {
@@ -21,7 +23,102 @@ const defaultStorage = (() => {
   };
 })();
 
-function sortScores(entries) {
+function normalizeMode(mode) {
+  return MODES.includes(mode) ? mode : 'human';
+}
+
+function normalizeDifficultyKey(value) {
+  if (!value && value !== 0) {
+    return 'unknown';
+  }
+  const key = String(value).trim().toLowerCase();
+  if (!key) {
+    return 'unknown';
+  }
+  if (key === 'advanced') {
+    return 'expert';
+  }
+  return key;
+}
+
+function fallbackLabelForKey(key) {
+  switch (key) {
+    case 'beginner':
+      return 'Beginner';
+    case 'intermediate':
+      return 'Intermediate';
+    case 'expert':
+      return 'Advanced';
+    case 'unknown':
+      return 'Unknown';
+    default: {
+      if (!key) {
+        return 'Unknown';
+      }
+      return key
+        .split(/[_\s-]+/)
+        .filter(Boolean)
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+    }
+  }
+}
+
+function normalizeDifficultyLabel(key, label) {
+  if (!label) {
+    return fallbackLabelForKey(key);
+  }
+  const normalized = normalizeDifficultyKey(label);
+  if (normalized === 'unknown') {
+    return fallbackLabelForKey(key);
+  }
+  if (normalized === 'expert') {
+    return 'Advanced';
+  }
+  if (normalized === key) {
+    return fallbackLabelForKey(key);
+  }
+  return String(label);
+}
+
+function createEmptyBoard(label = '') {
+  return {
+    label,
+    entries: [],
+    wins: 0,
+    losses: 0,
+  };
+}
+
+function createEmptyData() {
+  return {
+    version: STORAGE_VERSION,
+    human: {},
+    auto: {},
+  };
+}
+
+function normalizeEntry(entry = {}) {
+  const secondsNumber = Number(entry.seconds);
+  const seconds = Number.isFinite(secondsNumber) ? secondsNumber : 0;
+  let recordedAt = entry.recordedAt;
+  if (recordedAt) {
+    const date = new Date(recordedAt);
+    if (!Number.isNaN(date.getTime())) {
+      recordedAt = date.toISOString();
+    } else {
+      recordedAt = new Date().toISOString();
+    }
+  } else {
+    recordedAt = new Date().toISOString();
+  }
+  return {
+    seconds,
+    recordedAt,
+  };
+}
+
+function sortEntries(entries) {
   return entries
     .slice()
     .sort((a, b) => {
@@ -32,12 +129,103 @@ function sortScores(entries) {
     });
 }
 
-function normalizeEntry(entry) {
-  return {
-    difficulty: entry.difficulty,
-    seconds: Number(entry.seconds),
-    recordedAt: entry.recordedAt ?? new Date().toISOString(),
+function normalizeModeData(rawMode) {
+  const normalized = {};
+
+  const ensureBoard = (key, label = null) => {
+    const board = normalized[key] ?? createEmptyBoard();
+    if (!normalized[key]) {
+      normalized[key] = board;
+    }
+    if (label) {
+      board.label = normalizeDifficultyLabel(key, label);
+    } else if (!board.label) {
+      board.label = fallbackLabelForKey(key);
+    }
+    return board;
   };
+
+  const addEntriesToBoard = (key, label, entries) => {
+    const board = ensureBoard(key, label);
+    entries.forEach(entry => {
+      board.entries.push(normalizeEntry(entry));
+    });
+  };
+
+  if (Array.isArray(rawMode)) {
+    rawMode.forEach(entry => {
+      const key = normalizeDifficultyKey(entry?.difficulty ?? 'unknown');
+      const label = normalizeDifficultyLabel(key, entry?.difficulty);
+      addEntriesToBoard(key, label, [entry]);
+    });
+  } else if (rawMode && typeof rawMode === 'object') {
+    Object.entries(rawMode).forEach(([rawKey, value]) => {
+      const key = normalizeDifficultyKey(rawKey);
+      if (Array.isArray(value)) {
+        value.forEach(entry => {
+          const label = normalizeDifficultyLabel(key, entry?.difficulty ?? rawKey);
+          addEntriesToBoard(key, label, [entry]);
+        });
+        return;
+      }
+      if (!value || typeof value !== 'object') {
+        ensureBoard(key);
+        return;
+      }
+      const board = ensureBoard(key, value.label ?? value.difficulty ?? rawKey);
+      const wins = Number(value.wins);
+      if (Number.isFinite(wins) && wins >= 0) {
+        board.wins = wins;
+      }
+      const losses = Number(value.losses);
+      if (Number.isFinite(losses) && losses >= 0) {
+        board.losses = losses;
+      }
+      const entryGroups = [];
+      if (Array.isArray(value.entries)) {
+        entryGroups.push(value.entries);
+      }
+      if (Array.isArray(value.scores)) {
+        entryGroups.push(value.scores);
+      }
+      if (entryGroups.length === 0 && value.seconds !== undefined) {
+        entryGroups.push([value]);
+      }
+      entryGroups.forEach(group => {
+        addEntriesToBoard(key, board.label, group);
+      });
+    });
+  }
+
+  Object.entries(normalized).forEach(([key, board]) => {
+    board.label = normalizeDifficultyLabel(key, board.label);
+    board.entries = sortEntries(board.entries).slice(0, 10);
+    if (!Number.isFinite(board.wins) || board.wins < board.entries.length) {
+      board.wins = board.entries.length;
+    }
+    if (!Number.isFinite(board.losses) || board.losses < 0) {
+      board.losses = 0;
+    }
+  });
+
+  return normalized;
+}
+
+function cloneBoard(board) {
+  return {
+    label: board.label,
+    wins: board.wins,
+    losses: board.losses,
+    entries: board.entries.map(entry => ({ ...entry })),
+  };
+}
+
+function cloneMode(modeData = {}) {
+  const clone = {};
+  Object.entries(modeData).forEach(([key, board]) => {
+    clone[key] = cloneBoard(board);
+  });
+  return clone;
 }
 
 export class ScoreRepository {
@@ -49,57 +237,126 @@ export class ScoreRepository {
   _loadRaw() {
     const payload = this.storage.getItem(this.storageKey);
     if (!payload) {
-      return { human: [], auto: [] };
+      return createEmptyData();
     }
     try {
       const parsed = JSON.parse(payload);
-      return {
-        human: Array.isArray(parsed.human) ? parsed.human.map(normalizeEntry) : [],
-        auto: Array.isArray(parsed.auto) ? parsed.auto.map(normalizeEntry) : [],
-      };
+      const data = createEmptyData();
+      data.version = Number.isFinite(parsed?.version) ? parsed.version : STORAGE_VERSION;
+      MODES.forEach(mode => {
+        data[mode] = normalizeModeData(parsed?.[mode]);
+      });
+      return data;
     } catch (err) {
-      return { human: [], auto: [] };
+      return createEmptyData();
     }
   }
 
   _saveRaw(data) {
-    this.storage.setItem(this.storageKey, JSON.stringify(data));
-  }
-
-  getScores(mode = 'human') {
-    const data = this._loadRaw();
-    return sortScores(data[mode]).slice(0, 10);
-  }
-
-  addScore(mode, difficulty, seconds) {
-    const data = this._loadRaw();
-    const updated = sortScores([
-      ...data[mode],
-      normalizeEntry({ difficulty, seconds }),
-    ]).slice(0, 10);
-    const next = {
-      ...data,
-      [mode]: updated,
+    const payload = {
+      version: STORAGE_VERSION,
     };
-    this._saveRaw(next);
-    return updated;
+    MODES.forEach(mode => {
+      payload[mode] = {};
+      Object.entries(data[mode] ?? {}).forEach(([key, board]) => {
+        payload[mode][key] = {
+          label: normalizeDifficultyLabel(key, board.label),
+          wins: board.wins,
+          losses: board.losses,
+          entries: sortEntries(board.entries ?? []).slice(0, 10).map(entry => ({ ...entry })),
+        };
+      });
+    });
+    this.storage.setItem(this.storageKey, JSON.stringify(payload));
+  }
+
+  _ensureBoard(data, mode, difficultyKey, label = null) {
+    const safeMode = normalizeMode(mode);
+    const key = normalizeDifficultyKey(difficultyKey);
+    if (!data[safeMode]) {
+      data[safeMode] = {};
+    }
+    if (!data[safeMode][key]) {
+      data[safeMode][key] = createEmptyBoard();
+    }
+    const board = data[safeMode][key];
+    const normalizedLabel = normalizeDifficultyLabel(key, label ?? board.label);
+    board.label = normalizedLabel;
+    if (!Array.isArray(board.entries)) {
+      board.entries = [];
+    }
+    if (!Number.isFinite(board.wins)) {
+      board.wins = 0;
+    }
+    if (!Number.isFinite(board.losses)) {
+      board.losses = 0;
+    }
+    return board;
+  }
+
+  getLeaderboard(mode = 'human', difficultyKey, label = null) {
+    const data = this._loadRaw();
+    const board = this._ensureBoard(data, mode, difficultyKey, label);
+    return cloneBoard(board);
+  }
+
+  getAllLeaderboards() {
+    const data = this._loadRaw();
+    return {
+      version: data.version ?? STORAGE_VERSION,
+      human: cloneMode(data.human),
+      auto: cloneMode(data.auto),
+    };
+  }
+
+  recordWin(mode, difficultyKey, label, seconds) {
+    const data = this._loadRaw();
+    const board = this._ensureBoard(data, mode, difficultyKey, label);
+    const nextEntries = sortEntries([
+      ...board.entries,
+      normalizeEntry({ seconds }),
+    ]).slice(0, 10);
+    board.entries = nextEntries;
+    board.wins += 1;
+    this._saveRaw(data);
+    return cloneBoard(board);
+  }
+
+  recordLoss(mode, difficultyKey, label) {
+    const data = this._loadRaw();
+    const board = this._ensureBoard(data, mode, difficultyKey, label);
+    board.losses += 1;
+    this._saveRaw(data);
+    return cloneBoard(board);
+  }
+
+  clearLeaderboard(mode, difficultyKey, label = null) {
+    const data = this._loadRaw();
+    const board = this._ensureBoard(data, mode, difficultyKey, label);
+    board.entries = [];
+    board.wins = 0;
+    board.losses = 0;
+    this._saveRaw(data);
+    return cloneBoard(board);
   }
 
   mergeScores(payload) {
     const data = this._loadRaw();
-    const incoming = typeof payload === 'string' ? JSON.parse(payload) : payload;
-    const merged = {
-      human: sortScores([
-        ...data.human,
-        ...(Array.isArray(incoming.human) ? incoming.human.map(normalizeEntry) : []),
-      ]).slice(0, 10),
-      auto: sortScores([
-        ...data.auto,
-        ...(Array.isArray(incoming.auto) ? incoming.auto.map(normalizeEntry) : []),
-      ]).slice(0, 10),
-    };
-    this._saveRaw(merged);
-    return merged;
+    const incomingRaw = typeof payload === 'string' ? JSON.parse(payload) : payload;
+    const incoming = createEmptyData();
+    MODES.forEach(mode => {
+      incoming[mode] = normalizeModeData(incomingRaw?.[mode]);
+    });
+    MODES.forEach(mode => {
+      Object.entries(incoming[mode]).forEach(([key, board]) => {
+        const target = this._ensureBoard(data, mode, key, board.label);
+        target.entries = sortEntries([...target.entries, ...board.entries]).slice(0, 10);
+        target.wins += board.wins;
+        target.losses += board.losses;
+      });
+    });
+    this._saveRaw(data);
+    return this.getAllLeaderboards();
   }
 
   exportScores() {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -7,12 +7,13 @@ import { GameStatus } from '../old/minesweeper/scripts/game.js';
 test('a finished game only records the winning score once', () => {
   const scoreCalls = [];
   const scoreRepository = {
-    addScore(mode, difficulty, seconds) {
-      scoreCalls.push({ mode, difficulty, seconds });
-      return [];
+    recordWin(mode, difficultyKey, label, seconds) {
+      scoreCalls.push({ mode, difficultyKey, label, seconds });
+      return { label, wins: 0, losses: 0, entries: [] };
     },
-    getScores() {
-      return [];
+    recordLoss() {},
+    getLeaderboard() {
+      return { label: 'Test', wins: 0, losses: 0, entries: [] };
     },
   };
 
@@ -59,7 +60,8 @@ test('a finished game only records the winning score once', () => {
   assert.equal(scoreCalls.length, 1);
   assert.deepEqual(scoreCalls[0], {
     mode: 'human',
-    difficulty: 'Test',
+    difficultyKey: 'test',
+    label: 'Test',
     seconds: 12.34,
   });
 


### PR DESCRIPTION
## Summary
- restructure the score repository to track per-mode, per-difficulty leaderboards with win/loss counts and timestamps
- redesign the Minesweeper UI and markup to render separate user and auto leaderboards with clear buttons and updated styling
- extend the test suite for the new repository API and adjust the UI test to the win-tracking workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6c7f99bc8322aa94581280092cc8