### PR TITLE
Add sleepy solver AI and leaderboard name tracking

### DIFF
--- a/old/mine.html
+++ b/old/mine.html
@@ -104,6 +104,29 @@
       border: 1px solid rgba(59, 130, 246, 0.2);
       background: rgba(37, 99, 235, 0.08);
     }
+    .player-name-control {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      border-radius: 8px;
+      border: 1px solid rgba(15, 23, 42, 0.1);
+      background: rgba(148, 163, 184, 0.12);
+    }
+    .player-name-control label {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #1f2937;
+    }
+    #playerName {
+      border: 1px solid rgba(15, 23, 42, 0.2);
+      border-radius: 6px;
+      padding: 6px 10px;
+      font-size: 0.95rem;
+      min-width: 140px;
+    }
     .auto-controls label {
       font-size: 0.75rem;
       font-weight: 700;
@@ -133,6 +156,19 @@
     #autoStrategy:disabled {
       opacity: 0.6;
       cursor: not-allowed;
+    }
+    .persona-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: #1d4ed8;
+      text-decoration: none;
+    }
+    .persona-link:hover,
+    .persona-link:focus {
+      text-decoration: underline;
     }
     .auto-indicator {
       display: inline-flex;
@@ -310,12 +346,73 @@
       color: #64748b;
       font-style: italic;
     }
+    .score-name {
+      font-weight: 600;
+      color: #1d4ed8;
+    }
     .score-time {
       font-weight: 600;
       color: #0f172a;
     }
     .score-recorded {
       color: #64748b;
+    }
+    .player-stats {
+      margin-top: 24px;
+      padding-top: 16px;
+      border-top: 1px solid rgba(15, 23, 42, 0.15);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .player-stats h2 {
+      margin: 0;
+      font-size: 1.2rem;
+      color: #0f172a;
+    }
+    .player-stats > p {
+      margin: 0;
+      color: #475569;
+    }
+    .player-mode-stats {
+      padding: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-radius: 10px;
+      background: rgba(226, 232, 240, 0.35);
+    }
+    .player-mode-stats h3 {
+      margin-top: 0;
+      margin-bottom: 8px;
+      font-size: 1rem;
+      color: #1f2937;
+    }
+    .player-mode-stats p.empty-state {
+      margin: 0;
+      color: #64748b;
+      font-style: italic;
+    }
+    .player-stats-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+    .player-stats-table th,
+    .player-stats-table td {
+      padding: 6px 8px;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+      text-align: left;
+    }
+    .player-stats-table th {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: #475569;
+    }
+    .player-stats-table th[scope='row'] {
+      text-transform: none;
+      letter-spacing: normal;
+      color: #0f172a;
+      font-size: 0.95rem;
     }
     @media (min-width: 720px) {
       .mode-section {
@@ -349,17 +446,23 @@
         <button data-difficulty="intermediate">Intermediate</button>
         <button data-difficulty="expert">Advanced</button>
       </div>
+      <div class="player-name-control">
+        <label for="playerName">Leaderboard name</label>
+        <input id="playerName" name="playerName" type="text" value="alan" maxlength="40" aria-label="Set leaderboard name">
+      </div>
       <div class="actions">
         <div class="auto-controls">
           <label for="autoStrategy">AI Brain</label>
           <select id="autoStrategy" aria-label="Choose an auto pilot strategy">
             <option value="solver">Constraint Solver</option>
+            <option value="sleepy">Sleepy Constraint Solver</option>
             <option value="random">Random Explorer</option>
           </select>
           <span id="autoIndicator" class="auto-indicator" data-state="off">
             <span class="auto-dot"></span>
             <span class="auto-text">Auto Pilot Off</span>
           </span>
+          <a id="personaLink" class="persona-link" href="minesweeper/ai-solver.html" target="_blank" rel="noopener">Meet this AI</a>
         </div>
         <button id="autoButton" title="Let the AI take the wheel">Auto Pilot</button>
       </div>
@@ -385,6 +488,7 @@
       </div>
       <div id="leaderboardContainer" class="score-groups"></div>
     </div>
+    <section id="playerStats" class="player-stats"></section>
     <div class="copyright">
       <p>Game originally produced by Alan Rominger, 2015, now tuned up with modern JavaScript flair.</p>
       <p>All images were crafted in Paint. Keep tinkering, keep sharing, keep dodging mines.</p>

--- a/old/minesweeper/ai-random.html
+++ b/old/minesweeper/ai-random.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Captain Scatter &mdash; Random Explorer AI</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      margin: 0;
+      padding: 24px;
+      background: #d0e4fe;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: #0f172a;
+    }
+    .persona-card {
+      max-width: 720px;
+      margin: 0 auto;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
+      padding: 32px 28px;
+      display: grid;
+      gap: 16px;
+    }
+    .back-link {
+      text-decoration: none;
+      color: #2563eb;
+      font-weight: 600;
+    }
+    .back-link:hover,
+    .back-link:focus {
+      text-decoration: underline;
+    }
+    .hero {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+    }
+    .hero img {
+      width: 96px;
+      height: 96px;
+      border-radius: 24px;
+      background: #e2e8f0;
+      padding: 12px;
+      box-shadow: inset 0 0 0 3px rgba(234, 179, 8, 0.35);
+      image-rendering: pixelated;
+    }
+    h1 {
+      margin: 0;
+      font-size: 2rem;
+    }
+    .tagline {
+      margin: 0;
+      font-size: 1rem;
+      color: #475569;
+    }
+    section {
+      background: rgba(234, 179, 8, 0.08);
+      border-radius: 12px;
+      padding: 20px;
+      display: grid;
+      gap: 12px;
+    }
+    h2 {
+      margin: 0;
+      font-size: 1.25rem;
+      color: #b45309;
+    }
+    ul {
+      margin: 0;
+      padding-left: 20px;
+      color: #1f2937;
+    }
+    .footer-note {
+      margin: 0;
+      font-size: 0.9rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+  <main class="persona-card">
+    <a class="back-link" href="../mine.html">&larr; Back to Minesweeper</a>
+    <div class="hero">
+      <img src="uncertain.png" alt="Captain Scatter avatar">
+      <div>
+        <h1>Captain Scatter</h1>
+        <p class="tagline">Random Explorer AI brain</p>
+      </div>
+    </div>
+    <section>
+      <h2>Personality</h2>
+      <p>
+        Captain Scatter is the bold adventurer who lives for the thrill of the unknown. No complicated planning,
+        no constraint math&mdash;just pure exploratory spirit with a finger hovering over every unrevealed tile.
+      </p>
+      <ul>
+        <li>Ignores flags, probabilities, and patterns altogether.</li>
+        <li>Picks any hidden, unflagged tile uniformly at random each turn.</li>
+        <li>Clicks with reckless abandon until a mine appears or the board is miraculously cleared.</li>
+        <li>Perfect for stress-testing the lose counter and showing what pure luck looks like.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Under the hood</h2>
+      <p>
+        Captain Scatter keeps a running list of every cell that remains hidden and unflagged. Each move draws a random
+        index using the provided pseudo-random number generator and reveals that tile immediately. There is no memory
+        of previous outcomes and no regard for mine density&mdash;the algorithm is intentionally naive so players can
+        compare true logic against sheer chance.
+      </p>
+    </section>
+    <p class="footer-note">Warning: expect many dramatic explosions and almost zero victories.</p>
+  </main>
+</body>
+</html>

--- a/old/minesweeper/ai-sleepy.html
+++ b/old/minesweeper/ai-sleepy.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Rookie Cartographer &mdash; Sleepy Constraint Solver</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      margin: 0;
+      padding: 24px;
+      background: #d0e4fe;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: #0f172a;
+    }
+    .persona-card {
+      max-width: 720px;
+      margin: 0 auto;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
+      padding: 32px 28px;
+      display: grid;
+      gap: 16px;
+    }
+    .back-link {
+      text-decoration: none;
+      color: #2563eb;
+      font-weight: 600;
+    }
+    .back-link:hover,
+    .back-link:focus {
+      text-decoration: underline;
+    }
+    .hero {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+    }
+    .hero img {
+      width: 96px;
+      height: 96px;
+      border-radius: 24px;
+      background: #e2e8f0;
+      padding: 12px;
+      box-shadow: inset 0 0 0 3px rgba(14, 165, 233, 0.3);
+      image-rendering: pixelated;
+    }
+    h1 {
+      margin: 0;
+      font-size: 2rem;
+    }
+    .tagline {
+      margin: 0;
+      font-size: 1rem;
+      color: #475569;
+    }
+    section {
+      background: rgba(14, 165, 233, 0.08);
+      border-radius: 12px;
+      padding: 20px;
+      display: grid;
+      gap: 12px;
+    }
+    h2 {
+      margin: 0;
+      font-size: 1.25rem;
+      color: #0369a1;
+    }
+    ul {
+      margin: 0;
+      padding-left: 20px;
+      color: #1f2937;
+    }
+    .footer-note {
+      margin: 0;
+      font-size: 0.9rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+  <main class="persona-card">
+    <a class="back-link" href="../mine.html">&larr; Back to Minesweeper</a>
+    <div class="hero">
+      <img src="huh.png" alt="Rookie Cartographer avatar">
+      <div>
+        <h1>Rookie Cartographer</h1>
+        <p class="tagline">Sleepy Constraint Solver AI brain</p>
+      </div>
+    </div>
+    <section>
+      <h2>Personality</h2>
+      <p>
+        The Rookie Cartographer studied under Professor Gridlock but keeps nodding off mid-lesson. They follow most of
+        the logical playbook, yet they shy away from heavy calculations and are quick to make a hasty guess when the
+        board looks complicated.
+      </p>
+      <ul>
+        <li>Builds the same constraint graphs as the senior solver, but naps through anything bigger than eight tiles.</li>
+        <li>Flags certainties and reveals safe tiles uncovered by the reduced analysis.</li>
+        <li>When unsure, picks a random hidden tile using its personal RNG instead of evaluating risk.</li>
+        <li>Great for demonstrating how a tiny lapse in logic can spiral into more guesswork.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Under the hood</h2>
+      <p>
+        The sleepy solver still collects all numbered clues and groups neighbouring unknowns into components, but if a
+        cluster contains more than eight tiles it simply shrugs and walks away. Smaller components are fully enumerated
+        just like the main solver, so guaranteed mines and clears still appear. For the fallback guess, however, the
+        rookie discards probability calculations and chooses a random hidden cell instead, making it demonstrably less
+        reliable than the meticulous professor.
+      </p>
+    </section>
+    <p class="footer-note">Pair Rookie Cartographer against Professor Gridlock to see how missing logic changes the win rate.</p>
+  </main>
+</body>
+</html>

--- a/old/minesweeper/ai-solver.html
+++ b/old/minesweeper/ai-solver.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Professor Gridlock &mdash; Constraint Solver AI</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      margin: 0;
+      padding: 24px;
+      background: #d0e4fe;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: #0f172a;
+    }
+    .persona-card {
+      max-width: 720px;
+      margin: 0 auto;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
+      padding: 32px 28px;
+      display: grid;
+      gap: 16px;
+    }
+    .back-link {
+      text-decoration: none;
+      color: #2563eb;
+      font-weight: 600;
+    }
+    .back-link:hover,
+    .back-link:focus {
+      text-decoration: underline;
+    }
+    .hero {
+      display: flex;
+      gap: 16px;
+      align-items: center;
+    }
+    .hero img {
+      width: 96px;
+      height: 96px;
+      border-radius: 24px;
+      background: #e2e8f0;
+      padding: 12px;
+      box-shadow: inset 0 0 0 3px rgba(37, 99, 235, 0.2);
+      image-rendering: pixelated;
+    }
+    h1 {
+      margin: 0;
+      font-size: 2rem;
+    }
+    .tagline {
+      margin: 0;
+      font-size: 1rem;
+      color: #475569;
+    }
+    section {
+      background: rgba(37, 99, 235, 0.05);
+      border-radius: 12px;
+      padding: 20px;
+      display: grid;
+      gap: 12px;
+    }
+    h2 {
+      margin: 0;
+      font-size: 1.25rem;
+      color: #1e3a8a;
+    }
+    ul {
+      margin: 0;
+      padding-left: 20px;
+      color: #1f2937;
+    }
+    .footer-note {
+      margin: 0;
+      font-size: 0.9rem;
+      color: #475569;
+    }
+  </style>
+</head>
+<body>
+  <main class="persona-card">
+    <a class="back-link" href="../mine.html">&larr; Back to Minesweeper</a>
+    <div class="hero">
+      <img src="smile.png" alt="Professor Gridlock avatar">
+      <div>
+        <h1>Professor Gridlock</h1>
+        <p class="tagline">Constraint Solver AI brain</p>
+      </div>
+    </div>
+    <section>
+      <h2>Personality</h2>
+      <p>
+        Professor Gridlock is the methodical academic of the minefield. They catalog every numbered tile,
+        stitch together logical constraints, and refuse to click until the math checks out.
+      </p>
+      <ul>
+        <li>Meticulously builds a network of constraint groups from revealed numbers.</li>
+        <li>Enumerates every valid configuration for connected components up to 15 tiles wide.</li>
+        <li>Flags guaranteed mines and uncovers provably safe tiles without breaking a sweat.</li>
+        <li>When logic runs dry, they compute probabilities and pick the safest-looking guess on the board.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Under the hood</h2>
+      <p>
+        The constraint solver inspects each revealed number and records which hidden neighbours must contain mines.
+        Components of interdependent tiles are enumerated so that every consistent assignment is considered.
+        A tile is cleared immediately if its probability drops to 0, while certain mines are flagged when the
+        probability hits 1. If ambiguity remains, the professor chooses the lowest-risk candidate based on those
+        calculated odds, with a slight preference for tiles that touch fewer numbers.
+      </p>
+    </section>
+    <p class="footer-note">Tip: let Professor Gridlock loose on advanced boards to watch deliberate logic in action.</p>
+  </main>
+</body>
+</html>

--- a/old/minesweeper/scripts/autoPlayer.js
+++ b/old/minesweeper/scripts/autoPlayer.js
@@ -401,6 +401,36 @@ export class AutoPlayer {
   }
 }
 
+export class SleepyAutoPlayer extends AutoPlayer {
+  constructor(game, { delayMs = 40, rng = Math.random } = {}) {
+    super(game, { delayMs });
+    this._rng = rng;
+  }
+
+  _enumerateComponent(component) {
+    if (component.cells.length > 8) {
+      return null;
+    }
+    return super._enumerateComponent(component);
+  }
+
+  _chooseFallbackGuess() {
+    const candidates = [];
+    for (let r = 0; r < this.game.rows; r += 1) {
+      for (let c = 0; c < this.game.cols; c += 1) {
+        if (!this.game.revealed[r][c] && !this.game.flagged[r][c]) {
+          candidates.push({ row: r, col: c });
+        }
+      }
+    }
+    if (candidates.length === 0) {
+      return null;
+    }
+    const index = Math.min(candidates.length - 1, Math.floor(this._rng() * candidates.length));
+    return candidates[index];
+  }
+}
+
 export class RandomAutoPlayer {
   constructor(game, { delayMs = 40, rng = Math.random } = {}) {
     this.game = game;

--- a/tests/autoPlayer.test.js
+++ b/tests/autoPlayer.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { MinesweeperGame, GameStatus, MINE } from '../old/minesweeper/scripts/game.js';
-import { AutoPlayer, RandomAutoPlayer, applyAutoAction } from '../old/minesweeper/scripts/autoPlayer.js';
+import { AutoPlayer, RandomAutoPlayer, SleepyAutoPlayer, applyAutoAction } from '../old/minesweeper/scripts/autoPlayer.js';
 
 const layout = [
   [MINE, 1, 0, 1, MINE],
@@ -30,4 +30,27 @@ test('random auto player finishes the simplest safe board without flagging', asy
   });
   assert.equal(game.status, GameStatus.WON);
   assert.equal(game.flagged[0][0], false);
+});
+
+test('sleepy solver trims large components and leans on its rng for guesses', () => {
+  const game = new MinesweeperGame(2, 2, 0);
+  const sleepy = new SleepyAutoPlayer(game, { delayMs: 0, rng: () => 0.75 });
+  const largeComponent = {
+    cells: Array.from({ length: 9 }, (_, index) => ({ key: String(index) })),
+    constraints: [],
+  };
+  assert.equal(sleepy._enumerateComponent(largeComponent), null);
+
+  const smallComponent = {
+    cells: [
+      { key: '0', row: 0, col: 0 },
+      { key: '1', row: 0, col: 1 },
+    ],
+    constraints: [{ cells: ['0'], required: 1 }],
+  };
+  const analysis = sleepy._enumerateComponent(smallComponent);
+  assert.ok(analysis);
+
+  const guess = sleepy._chooseFallbackGuess();
+  assert.deepEqual(guess, { row: 1, col: 1 });
 });

--- a/tests/scoreboard.test.js
+++ b/tests/scoreboard.test.js
@@ -21,27 +21,40 @@ class MemoryStorage {
   }
 }
 
-test('recordWin keeps top ten scores per difficulty and tracks wins', () => {
+test('recordWin keeps top ten scores and tallies player stats', () => {
   const repo = new ScoreRepository(new MemoryStorage(), 'scores');
   for (let i = 0; i < 14; i += 1) {
-    repo.recordWin('human', 'beginner', 'Beginner', 20 - i);
+    repo.recordWin('human', 'beginner', 'Beginner', 20 - i, 'Alan');
   }
-  const leaderboard = repo.getLeaderboard('human', 'beginner', 'Beginner');
+  let leaderboard = repo.getLeaderboard('human', 'beginner', 'Beginner');
   assert.equal(leaderboard.entries.length, 10);
   assert.equal(leaderboard.wins, 14);
   assert.equal(leaderboard.losses, 0);
+  assert.ok(leaderboard.entries.every(entry => entry.name === 'Alan'));
   assert.ok(
     leaderboard.entries.every((entry, index, arr) => index === 0 || entry.seconds >= arr[index - 1].seconds),
   );
   assert.ok(leaderboard.entries.every(entry => typeof entry.recordedAt === 'string'));
+  assert.equal(leaderboard.entries[0].name, 'Alan');
+
+  repo.recordLoss('human', 'beginner', 'Beginner', 'Alan');
+  leaderboard = repo.getLeaderboard('human', 'beginner', 'Beginner');
+  assert.equal(leaderboard.losses, 1);
+
+  const stats = repo.getPlayerStats();
+  const humanPlayers = Object.values(stats.human);
+  assert.equal(humanPlayers.length, 1);
+  assert.equal(humanPlayers[0].name, 'Alan');
+  assert.equal(humanPlayers[0].difficulties.beginner.wins, 14);
+  assert.equal(humanPlayers[0].difficulties.beginner.losses, 1);
 });
 
 test('mergeScores combines legacy payloads and accumulates stats', () => {
   const storage = new MemoryStorage();
   const repo = new ScoreRepository(storage, 'scores');
-  repo.recordWin('human', 'beginner', 'Beginner', 15);
-  repo.recordLoss('human', 'beginner', 'Beginner');
-  repo.recordWin('auto', 'beginner', 'Beginner', 11);
+  repo.recordWin('human', 'beginner', 'Beginner', 15, 'Existing Human');
+  repo.recordLoss('human', 'beginner', 'Beginner', 'Existing Human');
+  repo.recordWin('auto', 'beginner', 'Beginner', 11, 'Professor Gridlock');
   const payload = JSON.stringify({
     human: [
       { difficulty: 'Intermediate', seconds: 12 },
@@ -54,6 +67,24 @@ test('mergeScores combines legacy payloads and accumulates stats', () => {
         entries: [{ seconds: 9, recordedAt: '2024-01-01T00:00:00.000Z' }],
       },
     },
+    players: {
+      human: {
+        champion: {
+          name: 'Champion',
+          difficulties: {
+            beginner: { wins: 3, losses: 2 },
+          },
+        },
+      },
+      auto: {
+        thinker: {
+          name: 'Thinker Bot',
+          difficulties: {
+            beginner: { wins: 1, losses: 4 },
+          },
+        },
+      },
+    },
   });
   repo.mergeScores(payload);
   const humanBeginner = repo.getLeaderboard('human', 'beginner', 'Beginner');
@@ -61,6 +92,7 @@ test('mergeScores combines legacy payloads and accumulates stats', () => {
   const autoBeginner = repo.getLeaderboard('auto', 'beginner', 'Beginner');
 
   assert.equal(humanBeginner.entries[0].seconds, 8);
+  assert.equal(humanBeginner.entries[0].name, 'anonymous');
   assert.equal(humanBeginner.wins, 2);
   assert.equal(humanBeginner.losses, 1);
 
@@ -68,6 +100,28 @@ test('mergeScores combines legacy payloads and accumulates stats', () => {
   assert.equal(humanIntermediate.wins, 1);
 
   assert.equal(autoBeginner.entries[0].seconds, 9);
+  assert.equal(autoBeginner.entries[0].name, 'anonymous');
   assert.equal(autoBeginner.wins, 3);
   assert.equal(autoBeginner.losses, 1);
+
+  const stats = repo.getPlayerStats();
+  const existingHuman = Object.values(stats.human).find(player => player.name === 'Existing Human');
+  assert.ok(existingHuman);
+  assert.equal(existingHuman.difficulties.beginner.wins, 1);
+  assert.equal(existingHuman.difficulties.beginner.losses, 1);
+
+  const champion = Object.values(stats.human).find(player => player.name === 'Champion');
+  assert.ok(champion);
+  assert.equal(champion.difficulties.beginner.wins, 3);
+  assert.equal(champion.difficulties.beginner.losses, 2);
+
+  const professor = Object.values(stats.auto).find(player => player.name === 'Professor Gridlock');
+  assert.ok(professor);
+  assert.equal(professor.difficulties.beginner.wins, 1);
+  assert.equal(professor.difficulties.beginner.losses, 0);
+
+  const thinker = Object.values(stats.auto).find(player => player.name === 'Thinker Bot');
+  assert.ok(thinker);
+  assert.equal(thinker.difficulties.beginner.wins, 1);
+  assert.equal(thinker.difficulties.beginner.losses, 4);
 });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -7,13 +7,16 @@ import { GameStatus } from '../old/minesweeper/scripts/game.js';
 test('a finished game only records the winning score once', () => {
   const scoreCalls = [];
   const scoreRepository = {
-    recordWin(mode, difficultyKey, label, seconds) {
-      scoreCalls.push({ mode, difficultyKey, label, seconds });
+    recordWin(mode, difficultyKey, label, seconds, playerName) {
+      scoreCalls.push({ mode, difficultyKey, label, seconds, playerName });
       return { label, wins: 0, losses: 0, entries: [] };
     },
     recordLoss() {},
     getLeaderboard() {
       return { label: 'Test', wins: 0, losses: 0, entries: [] };
+    },
+    getPlayerStats() {
+      return { human: {}, auto: {} };
     },
   };
 
@@ -63,6 +66,7 @@ test('a finished game only records the winning score once', () => {
     difficultyKey: 'test',
     label: 'Test',
     seconds: 12.34,
+    playerName: 'anonymous',
   });
 
   ui._applyRevealResult({ action: 'noop', revealed: [] });


### PR DESCRIPTION
## Summary
- add a Sleepy Constraint Solver auto-player option and publish persona pages for each AI
- capture a leaderboard name for every result, display it in leaderboards, and render per-player win/loss summaries
- update score storage, UI, and tests to accommodate named records and new AI behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd888b79b08322b1f647d3d1e482d6