### PR TITLE
Fix relative asset paths for minesweeper project

### DIFF
--- a/projects/minesweeper/index.html
+++ b/projects/minesweeper/index.html
@@ -282,7 +282,7 @@
       width: 32px;
       height: 32px;
       background-color: transparent;
-      background-image: url('minesweeper/tile.png');
+      background-image: url('./tile.png');
       background-size: contain;
       background-repeat: no-repeat;
       background-position: center;
@@ -564,7 +564,7 @@
             <span class="auto-dot"></span>
             <span class="auto-text">Auto Pilot Off</span>
           </span>
-          <a id="personaLink" class="persona-link" href="minesweeper/ai-solver.html" target="_blank" rel="noopener">Meet this AI</a>
+          <a id="personaLink" class="persona-link" href="./ai-solver.html" target="_blank" rel="noopener">Meet this AI</a>
         </div>
         <div class="auto-restart-controls">
           <span id="autoRestartIndicator" class="auto-indicator" data-state="off">
@@ -589,7 +589,7 @@
     </div>
     <div class="status-panel">
       <p>Tap the face to start over whenever the mood strikes.</p>
-      <img id="theSmiley" src="minesweeper/smile.png" alt="Start a new game">
+      <img id="theSmiley" src="./smile.png" alt="Start a new game">
       <div class="metrics">
         <div>⏱️ Time: <span id="timer">0.00s</span></div>
         <div>🚩 Mines remaining: <span id="mCount">0</span></div>
@@ -626,6 +626,6 @@
       <p>All images were crafted in Paint. Keep tinkering, keep sharing, keep dodging mines.</p>
     </div>
   </div>
-  <script type="module" src="minesweeper/scripts/main.js"></script>
+  <script type="module" src="./scripts/main.js"></script>
 </body>
 </html>

--- a/projects/minesweeper/scripts/ui.js
+++ b/projects/minesweeper/scripts/ui.js
@@ -9,21 +9,21 @@ const difficulties = {
 };
 
 const FACE_IMAGES = {
-  smile: 'minesweeper/smile.png',
-  frown: 'minesweeper/frown.png',
-  glasses: 'minesweeper/glasses.png',
-  wink: 'minesweeper/wink.png',
-  smug: 'minesweeper/smug.png',
-  huh: 'minesweeper/huh.png',
-  uncertain: 'minesweeper/uncertain.png',
+  smile: './smile.png',
+  frown: './frown.png',
+  glasses: './glasses.png',
+  wink: './wink.png',
+  smug: './smug.png',
+  huh: './huh.png',
+  uncertain: './uncertain.png',
 };
 
 const TILE_IMAGES = {
-  hidden: 'minesweeper/tile.png',
-  flag: 'minesweeper/flag.png',
-  mine: 'minesweeper/mine.png',
-  exploded: 'minesweeper/blown.png',
-  zero: 'minesweeper/grey.png',
+  hidden: './tile.png',
+  flag: './flag.png',
+  mine: './mine.png',
+  exploded: './blown.png',
+  zero: './grey.png',
 };
 
 const AUTO_STRATEGIES = {
@@ -31,7 +31,7 @@ const AUTO_STRATEGIES = {
     label: 'Constraint Solver',
     persona: {
       name: 'Professor Gridlock',
-      page: 'minesweeper/ai-solver.html',
+      page: './ai-solver.html',
     },
     create: game => new AutoPlayer(game),
   },
@@ -39,7 +39,7 @@ const AUTO_STRATEGIES = {
     label: 'Sleepy Constraint Solver',
     persona: {
       name: 'Rookie Cartographer',
-      page: 'minesweeper/ai-sleepy.html',
+      page: './ai-sleepy.html',
     },
     create: game => new SleepyAutoPlayer(game),
   },
@@ -47,7 +47,7 @@ const AUTO_STRATEGIES = {
     label: 'Random Explorer',
     persona: {
       name: 'Captain Scatter',
-      page: 'minesweeper/ai-random.html',
+      page: './ai-random.html',
     },
     create: game => new RandomAutoPlayer(game),
   },
@@ -63,7 +63,7 @@ function imageForValue(value) {
   if (value === 0) {
     return TILE_IMAGES.zero;
   }
-  return `minesweeper/${value}.png`;
+  return `./${value}.png`;
 }
 
 export class MinesweeperUI {


### PR DESCRIPTION
## Summary
- update the Minesweeper HTML to reference local assets with relative `./` paths so GitHub Pages serves them correctly
- align the UI configuration with the same relative paths for face, tile, and persona links to match the moved files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d2a8e27d048322acb688a934629222