### PR TITLE
Add achievements hub and enhance word jumble leaderboard

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -673,6 +673,15 @@
     color: darken($grey-color, 12%);
 }
 
+.achievement-item__game {
+    margin: 0 0 0.35rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: lighten($grey-color, 10%);
+    font-weight: 600;
+}
+
 .achievement-toast-container {
     position: fixed;
     top: 0;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -384,6 +384,33 @@
     gap: $spacing-unit;
 }
 
+.achievements-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: flex-start;
+}
+
+.achievements-nav__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.15s ease, background-color 0.15s ease;
+}
+
+.achievements-nav__link:hover,
+.achievements-nav__link:focus {
+    background: rgba(59, 130, 246, 0.2);
+    transform: translateY(-1px);
+}
+
 .achievements-hero {
     display: flex;
     flex-wrap: wrap;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -414,7 +414,7 @@
 
 .achievements-hero__copy h1 {
     margin: 0 0 0.35rem;
-    font-size: clamp(1.8rem, 2.2vw + 1rem, 2.4rem);
+    font-size: clamp(1.8rem, calc(1rem + 2.2vw), 2.4rem);
 }
 
 .achievements-hero__copy p {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -309,6 +309,37 @@
     opacity: 0.8;
 }
 
+.home-achievements-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: $spacing-unit / 2;
+    padding: 0.6rem 1.4rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #facc15, #f97316);
+    color: #1f2937;
+    font-weight: 700;
+    text-decoration: none;
+    box-shadow: 0 10px 22px rgba(249, 115, 22, 0.25);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.home-achievements-link:hover,
+.home-achievements-link:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 26px rgba(249, 115, 22, 0.35);
+    text-decoration: none;
+}
+
+.home-achievements-link__icon {
+    font-size: 1.4rem;
+}
+
+.home-achievements-link__text {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
 .home-links a {
     font-weight: 600;
 }
@@ -344,5 +375,316 @@
     .home-placeholders > li {
         flex-direction: column;
         text-align: center;
+    }
+}
+
+.achievements-page {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-unit;
+}
+
+.achievements-hero {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-unit;
+    align-items: center;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(14, 116, 144, 0.08));
+    border: 1px solid rgba(59, 130, 246, 0.25);
+    border-radius: 18px;
+    padding: $spacing-unit / 1.5;
+    box-shadow: 0 18px 32px rgba(15, 23, 42, 0.12);
+}
+
+.achievements-hero__art {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.8);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.achievements-hero__art img {
+    width: 64px;
+    height: 64px;
+    border-radius: 16px;
+    object-fit: contain;
+}
+
+.achievements-hero__copy h1 {
+    margin: 0 0 0.35rem;
+    font-size: clamp(1.8rem, 2.2vw + 1rem, 2.4rem);
+}
+
+.achievements-hero__copy p {
+    margin: 0;
+    font-size: 1rem;
+    color: $grey-color;
+}
+
+.achievements-grid {
+    display: grid;
+    gap: $spacing-unit;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.achievement-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 16px;
+    padding: $spacing-unit / 1.5;
+    box-shadow: 0 20px 36px rgba(15, 23, 42, 0.14);
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-unit / 2;
+}
+
+.achievement-card__header {
+    display: flex;
+    gap: $spacing-unit / 2;
+    align-items: center;
+}
+
+.achievement-card__icon {
+    width: 72px;
+    height: 72px;
+    display: grid;
+    place-items: center;
+    border-radius: 18px;
+    background: rgba(59, 130, 246, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.25);
+}
+
+.achievement-card__icon img {
+    width: 60px;
+    height: 60px;
+}
+
+.achievement-card__icon--glow {
+    background: radial-gradient(circle at top, rgba(251, 191, 36, 0.25), rgba(249, 115, 22, 0.18));
+    box-shadow: inset 0 0 0 1px rgba(249, 115, 22, 0.3);
+}
+
+.achievement-card__icon--court {
+    background: radial-gradient(circle, rgba(96, 165, 250, 0.22), rgba(56, 189, 248, 0.16));
+    box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.35);
+}
+
+.achievement-card__lead {
+    margin: 0;
+    color: $grey-color;
+}
+
+.achievement-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.achievement-table th,
+.achievement-table td {
+    padding: 8px 10px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+    text-align: left;
+}
+
+.achievement-table th {
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 0.06em;
+    color: #1d4ed8;
+}
+
+.achievement-empty {
+    margin: 0;
+    text-align: center;
+    font-style: italic;
+    color: $grey-color;
+}
+
+.achievement-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.achievement-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.65rem 0.9rem;
+    border-radius: 12px;
+    background: rgba(59, 130, 246, 0.08);
+    font-weight: 600;
+}
+
+.achievement-word {
+    letter-spacing: 0.06em;
+    color: #1f2937;
+}
+
+.achievement-word__score {
+    color: #1d4ed8;
+    font-size: 0.9rem;
+}
+
+.achievement-stats {
+    margin: 0;
+}
+
+.achievement-stats__row {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.4rem 0;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.achievement-stats__row:last-child {
+    border-bottom: none;
+}
+
+.achievement-stats dt {
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.achievement-stats dd {
+    margin: 0;
+    font-weight: 700;
+    color: #2563eb;
+}
+
+.achievements-management {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-unit / 1.5;
+    margin-top: $spacing-unit / 2;
+}
+
+.achievements-management__intro {
+    margin: 0;
+    color: $grey-color;
+}
+
+.management-card {
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: 14px;
+    padding: $spacing-unit / 1.5;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-unit / 2.5;
+}
+
+.management-card__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.management-card__grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    align-items: end;
+}
+
+.management-card button,
+.management-card select,
+.management-card label span {
+    font-weight: 600;
+}
+
+.management-card label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.9rem;
+}
+
+.management-card select {
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.5);
+    padding: 0.45rem 0.6rem;
+}
+
+.management-import {
+    position: relative;
+    overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.14);
+    cursor: pointer;
+}
+
+.management-import input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.management-clear {
+    border: none;
+    border-radius: 999px;
+    padding: 0.55rem 1.2rem;
+    background: rgba(244, 114, 182, 0.18);
+    color: #be185d;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.management-clear:hover,
+.management-clear:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 16px rgba(236, 72, 153, 0.2);
+}
+
+.management-clear--danger {
+    background: rgba(239, 68, 68, 0.18);
+    color: #b91c1c;
+}
+
+.management-message {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #475569;
+}
+
+.management-message[data-state='success'] {
+    color: #0f766e;
+}
+
+.management-message[data-state='error'] {
+    color: #b91c1c;
+}
+
+.management-message[data-state='warning'] {
+    color: #b45309;
+}
+
+@include media-query($on-palm) {
+    .achievements-hero {
+        justify-content: center;
+        text-align: center;
+    }
+
+    .achievement-card__header {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .achievement-list li {
+        flex-direction: column;
+        gap: 0.25rem;
+    }
+
+    .management-card__controls {
+        justify-content: center;
     }
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -502,6 +502,17 @@
     color: $grey-color;
 }
 
+.u-screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
 .achievement-table {
     width: 100%;
     border-collapse: collapse;
@@ -580,6 +591,136 @@
     margin: 0;
     font-weight: 700;
     color: #2563eb;
+}
+
+.achievements-trophies {
+    margin-top: $spacing-unit;
+    padding: $spacing-unit;
+    border-radius: 24px;
+    background: linear-gradient(135deg, rgba(17, 24, 39, 0.04), rgba(30, 64, 175, 0.08));
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+}
+
+.achievements-trophies__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: $spacing-unit / 1.5;
+    flex-wrap: wrap;
+}
+
+.achievements-trophies__lead {
+    margin: 0;
+    color: darken($grey-color, 8%);
+}
+
+.achievements-trophies__count {
+    margin: 0;
+    font-weight: 600;
+    color: #1e3a8a;
+}
+
+.achievements-trophies__list {
+    list-style: none;
+    padding: 0;
+    margin: $spacing-unit 0 0;
+    display: grid;
+    gap: $spacing-unit / 1.25;
+}
+
+.achievement-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: $spacing-unit / 1.5;
+    align-items: center;
+    padding: 1rem 1.2rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.14);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.achievement-item--unlocked {
+    border-color: rgba(22, 163, 74, 0.45);
+    box-shadow: 0 20px 32px rgba(22, 163, 74, 0.18);
+    background: linear-gradient(135deg, rgba(74, 222, 128, 0.2), rgba(34, 197, 94, 0.12));
+}
+
+.achievement-item__status {
+    width: 44px;
+    height: 44px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    font-size: 1.5rem;
+    font-weight: 700;
+    background: rgba(148, 163, 184, 0.25);
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.achievement-item--unlocked .achievement-item__status {
+    background: rgba(34, 197, 94, 0.18);
+    color: #15803d;
+}
+
+.achievement-item__body h3 {
+    margin: 0 0 0.25rem;
+    font-size: 1.15rem;
+}
+
+.achievement-item__body p {
+    margin: 0;
+    color: darken($grey-color, 12%);
+}
+
+.achievement-toast-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 4vh 1rem 1rem;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    z-index: 1000;
+}
+
+.achievement-toast-container.is-active {
+    opacity: 1;
+}
+
+.achievement-toast {
+    max-width: min(420px, 92vw);
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(14, 116, 144, 0.92));
+    color: white;
+    padding: 1.1rem 1.35rem;
+    border-radius: 20px;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.32);
+    border: 1px solid rgba(191, 219, 254, 0.4);
+    backdrop-filter: blur(12px);
+}
+
+.achievement-toast__eyebrow {
+    margin: 0 0 0.35rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    color: rgba(226, 232, 240, 0.9);
+}
+
+.achievement-toast__title {
+    margin: 0 0 0.35rem;
+    font-size: 1.4rem;
+}
+
+.achievement-toast__body {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(226, 232, 240, 0.92);
 }
 
 .achievements-management {
@@ -709,6 +850,19 @@
     .achievement-list li {
         flex-direction: column;
         gap: 0.25rem;
+    }
+
+    .achievements-trophies {
+        padding: $spacing-unit / 1.5;
+    }
+
+    .achievement-item {
+        grid-template-columns: 1fr;
+    }
+
+    .achievement-item__status {
+        margin-bottom: 0.5rem;
+        justify-self: flex-start;
     }
 
     .management-card__controls {

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ layout: default
     </ul>
     <a class="home-achievements-link" href="{{ '/projects/' | relative_url }}">
       <span class="home-achievements-link__icon" aria-hidden="true">⚡</span>
-      <span class="home-achievements-link__text">View your cross-game achievements</span>
+      <span class="home-achievements-link__text">view your game zone achievements</span>
     </a>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -16,16 +16,6 @@ layout: default
   </header>
 
   <section class="home-section">
-    <h2 class="section-heading">Profiles</h2>
-    <ul class="home-links">
-      <li><a href="https://www.linkedin.com/in/alan-rominger-40236518">LinkedIn</a></li>
-      <li><a href="https://github.com/AlanCoding">GitHub</a></li>
-      <li><a href="http://physics.stackexchange.com/users/1255/alan-rominger">Physics Stack Exchange</a></li>
-      <li><a href="https://www.inaturalist.org/people/8281527">INaturalist</a></li>
-    </ul>
-  </section>
-
-  <section class="home-section">
     <h2 class="section-heading">Alan's Game Zone</h2>
     <p class="section-description">
       I hand-wrote the minesweeper and work-jumble originally.
@@ -33,8 +23,7 @@ layout: default
       Whenver the AI writes text it's totally cringe, which you can see in some of the "blog" posts below.
     </p>
     <p class="section-description">
-      TODO: Add acheivements. Games unified progress page. Add records for word jumble.
-      Add levels to basketball game. Add tentative "pink goo" game.
+      The new achievements hub keeps score across every challenge. More levels and experiments are always simmering.
     </p>
     <ul class="home-links home-links--games">
       <li>
@@ -76,6 +65,20 @@ layout: default
           <p class="home-game-description">Launch nonstop free throws in a frantic showdown.</p>
         </div>
       </li>
+    </ul>
+    <a class="home-achievements-link" href="{{ '/projects/' | relative_url }}">
+      <span class="home-achievements-link__icon" aria-hidden="true">⚡</span>
+      <span class="home-achievements-link__text">View your cross-game achievements</span>
+    </a>
+  </section>
+
+  <section class="home-section">
+    <h2 class="section-heading">Profiles</h2>
+    <ul class="home-links">
+      <li><a href="https://www.linkedin.com/in/alan-rominger-40236518">LinkedIn</a></li>
+      <li><a href="https://github.com/AlanCoding">GitHub</a></li>
+      <li><a href="http://physics.stackexchange.com/users/1255/alan-rominger">Physics Stack Exchange</a></li>
+      <li><a href="https://www.inaturalist.org/people/8281527">INaturalist</a></li>
     </ul>
   </section>
 

--- a/projects/achievements.js
+++ b/projects/achievements.js
@@ -1,0 +1,294 @@
+import { ScoreRepository, formatSeconds } from './minesweeper/scripts/scoreboard.js';
+
+const MINESWEEPER_DIFFICULTIES = [
+  { key: 'beginner', label: 'Beginner' },
+  { key: 'intermediate', label: 'Intermediate' },
+  { key: 'expert', label: 'Advanced' },
+];
+
+const WORD_JUMBLE_STORAGE_KEY = 'word_jumble_power_stats_v1';
+const BASKETBALL_COOKIE = 'rapid_fire_runs_level1_v1';
+
+function renderMinesweeperSummary(repo) {
+  const tbody = document.getElementById('minesweeperSummary');
+  const emptyState = document.getElementById('minesweeperEmpty');
+  if (!tbody) {
+    return;
+  }
+  tbody.innerHTML = '';
+  let hasWin = false;
+  MINESWEEPER_DIFFICULTIES.forEach(difficulty => {
+    const board = repo.getLeaderboard('human', difficulty.key, difficulty.label);
+    const bestEntry = Array.isArray(board.entries) && board.entries.length > 0 ? board.entries[0] : null;
+    if (bestEntry) {
+      hasWin = true;
+    }
+    const row = document.createElement('tr');
+    const nameCell = document.createElement('th');
+    nameCell.scope = 'row';
+    nameCell.textContent = difficulty.label;
+    const timeCell = document.createElement('td');
+    timeCell.textContent = bestEntry ? formatSeconds(bestEntry.seconds) : '—';
+    const winsCell = document.createElement('td');
+    winsCell.textContent = String(board.wins ?? 0);
+    row.appendChild(nameCell);
+    row.appendChild(timeCell);
+    row.appendChild(winsCell);
+    tbody.appendChild(row);
+  });
+  if (emptyState) {
+    emptyState.hidden = hasWin;
+  }
+}
+
+function loadWordJumbleEntries() {
+  try {
+    const payload = window.localStorage.getItem(WORD_JUMBLE_STORAGE_KEY);
+    if (!payload) {
+      return [];
+    }
+    const parsed = JSON.parse(payload);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed;
+  } catch (error) {
+    return [];
+  }
+}
+
+function renderWordJumbleSummary() {
+  const list = document.getElementById('wordJumbleHighlights');
+  const emptyState = document.getElementById('wordJumbleEmpty');
+  if (!list) {
+    return;
+  }
+  const entries = loadWordJumbleEntries().slice();
+  entries.sort((a, b) => {
+    const countDiff = (b.count || 0) - (a.count || 0);
+    if (countDiff !== 0) {
+      return countDiff;
+    }
+    const timeDiff = (b.updatedAt || '').localeCompare(a.updatedAt || '');
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+    return (a.word || '').localeCompare(b.word || '');
+  });
+  const highlights = entries.slice(0, 5);
+  list.innerHTML = '';
+  if (highlights.length === 0) {
+    if (emptyState) {
+      emptyState.hidden = false;
+    }
+    return;
+  }
+  if (emptyState) {
+    emptyState.hidden = true;
+  }
+  highlights.forEach(entry => {
+    const item = document.createElement('li');
+    const wordSpan = document.createElement('span');
+    wordSpan.className = 'achievement-word';
+    wordSpan.textContent = (entry.display || entry.word || '').toUpperCase();
+    const scoreSpan = document.createElement('span');
+    scoreSpan.className = 'achievement-word__score';
+    scoreSpan.textContent = `${entry.count || 0} anagrams`;
+    item.appendChild(wordSpan);
+    item.appendChild(scoreSpan);
+    list.appendChild(item);
+  });
+}
+
+function parseBasketballHistory() {
+  const cookieValue = readCookie(BASKETBALL_COOKIE);
+  if (!cookieValue) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(cookieValue);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map(entry => normalizeBasketballEntry(entry))
+      .filter(Boolean)
+      .sort((a, b) => {
+        if ((b.score || 0) !== (a.score || 0)) {
+          return (b.score || 0) - (a.score || 0);
+        }
+        return (b.timestamp || '').localeCompare(a.timestamp || '');
+      });
+  } catch (error) {
+    return [];
+  }
+}
+
+function normalizeBasketballEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const timestamp = typeof entry.timestamp === 'string' ? entry.timestamp : null;
+  const score = Number(entry.score);
+  if (!timestamp || !Number.isFinite(score)) {
+    return null;
+  }
+  return {
+    timestamp,
+    score: Math.max(0, Math.floor(score)),
+  };
+}
+
+function renderBasketballSummary() {
+  const statsContainer = document.getElementById('basketballStats');
+  const emptyState = document.getElementById('basketballEmpty');
+  const bestEl = document.getElementById('basketballBest');
+  const bestDateEl = document.getElementById('basketballBestDate');
+  const runsEl = document.getElementById('basketballRuns');
+  const records = parseBasketballHistory();
+  if (!statsContainer || !bestEl || !bestDateEl || !runsEl) {
+    return;
+  }
+  runsEl.textContent = String(records.length);
+  if (records.length === 0) {
+    bestEl.textContent = '—';
+    bestDateEl.textContent = '—';
+    if (emptyState) {
+      emptyState.hidden = false;
+    }
+    return;
+  }
+  if (emptyState) {
+    emptyState.hidden = true;
+  }
+  const best = records[0];
+  bestEl.textContent = `${best.score}`;
+  const date = new Date(best.timestamp);
+  bestDateEl.textContent = Number.isNaN(date.getTime()) ? best.timestamp : date.toLocaleString();
+}
+
+function setupMinesweeperManagement(repo) {
+  const downloadBtn = document.getElementById('manageDownloadScores');
+  const importInput = document.getElementById('manageImportScores');
+  const modeSelect = document.getElementById('manageMode');
+  const difficultySelect = document.getElementById('manageDifficulty');
+  const clearSelectedBtn = document.getElementById('manageClearSelected');
+  const clearAllBtn = document.getElementById('manageClearAll');
+  const messageEl = document.getElementById('manageMessage');
+
+  function setMessage(text, type = 'info') {
+    if (!messageEl) {
+      return;
+    }
+    messageEl.textContent = text;
+    messageEl.dataset.state = type;
+  }
+
+  if (downloadBtn) {
+    downloadBtn.addEventListener('click', () => {
+      const payload = repo.exportScores();
+      const blob = new Blob([payload], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = 'minesweeper-scores.json';
+      anchor.click();
+      URL.revokeObjectURL(url);
+      setMessage('Scores downloaded to your device.');
+    });
+  }
+
+  if (importInput) {
+    importInput.addEventListener('change', async event => {
+      const file = event.target.files?.[0];
+      if (!file) {
+        return;
+      }
+      try {
+        const text = await file.text();
+        repo.mergeScores(text);
+        renderMinesweeperSummary(repo);
+        setMessage('Scores imported successfully.', 'success');
+      } catch (error) {
+        setMessage('Unable to import scores. Try a valid minesweeper JSON export.', 'error');
+      } finally {
+        event.target.value = '';
+      }
+    });
+  }
+
+  if (clearSelectedBtn && modeSelect && difficultySelect) {
+    clearSelectedBtn.addEventListener('click', () => {
+      const mode = modeSelect.value || 'human';
+      const difficultyKey = difficultySelect.value || 'beginner';
+      const difficulty = MINESWEEPER_DIFFICULTIES.find(item => item.key === difficultyKey) || MINESWEEPER_DIFFICULTIES[0];
+      repo.clearLeaderboard(mode, difficulty.key, difficulty.label);
+      renderMinesweeperSummary(repo);
+      const modeLabel = mode === 'auto' ? 'Auto' : 'Human';
+      setMessage(`${modeLabel} ${difficulty.label} leaderboard cleared.`, 'warning');
+    });
+  }
+
+  if (clearAllBtn) {
+    clearAllBtn.addEventListener('click', () => {
+      repo.clear();
+      renderMinesweeperSummary(repo);
+      setMessage('All minesweeper leaderboards cleared.', 'warning');
+    });
+  }
+}
+
+function setupWordJumbleManagement() {
+  const resetBtn = document.getElementById('manageWordReset');
+  const messageEl = document.getElementById('manageWordMessage');
+  if (!resetBtn) {
+    return;
+  }
+  resetBtn.addEventListener('click', () => {
+    try {
+      window.localStorage.removeItem(WORD_JUMBLE_STORAGE_KEY);
+    } catch (error) {
+      // ignore storage removal failures
+    }
+    renderWordJumbleSummary();
+    if (messageEl) {
+      messageEl.textContent = 'Word Jumble leaderboard cleared.';
+    }
+  });
+}
+
+function setupBasketballManagement() {
+  const resetBtn = document.getElementById('manageBasketballReset');
+  const messageEl = document.getElementById('manageBasketballMessage');
+  if (!resetBtn) {
+    return;
+  }
+  resetBtn.addEventListener('click', () => {
+    writeCookie(BASKETBALL_COOKIE, '', -1);
+    renderBasketballSummary();
+    if (messageEl) {
+      messageEl.textContent = 'Rapid Fire run history cleared.';
+    }
+  });
+}
+
+function readCookie(name) {
+  const escaped = name.replace(/([.*+?^${}()|[\]\\])/g, '\\$1');
+  const match = document.cookie.match(new RegExp(`(?:^|; )${escaped}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function writeCookie(name, value, days = 365) {
+  const maxAge = Math.floor(days * 24 * 60 * 60);
+  document.cookie = `${name}=${encodeURIComponent(value)};max-age=${maxAge};path=/;SameSite=Lax`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const repo = new ScoreRepository();
+  renderMinesweeperSummary(repo);
+  renderWordJumbleSummary();
+  renderBasketballSummary();
+  setupMinesweeperManagement(repo);
+  setupWordJumbleManagement();
+  setupBasketballManagement();
+});

--- a/projects/basketball/index.html
+++ b/projects/basketball/index.html
@@ -352,10 +352,12 @@
       </table>
     </section>
   </main>
+  <script src="../shared/achievements.js"></script>
   <script src="common.js"></script>
   <script>
     window.RapidFireFreeThrows.initGame({
       historyCookie: 'rapid_fire_runs_level1_v1',
+      levelKey: 'level1',
       unlockThreshold: 70,
       unlockLockedText: 'Score 70+ on Level 1 to unlock.',
       unlockUnlockedText: 'Level 2 unlocked!',

--- a/projects/basketball/level2.html
+++ b/projects/basketball/level2.html
@@ -441,10 +441,12 @@
     </section>
   </main>
 
+  <script src="../shared/achievements.js"></script>
   <script src="common.js"></script>
   <script>
     window.RapidFireFreeThrows.initGame({
       historyCookie: 'rapid_fire_runs_level2_v1',
+      levelKey: 'level2',
       unlockThreshold: 70,
       unlockLockedText: 'Reach 70+ on Level 1 to unlock this level.',
       unlockUnlockedText: 'Level 2 unlocked! Guide the board to redirect shots.',

--- a/projects/index.html
+++ b/projects/index.html
@@ -86,6 +86,17 @@ permalink: /projects/
     </article>
   </section>
 
+  <section class="achievements-trophies" aria-labelledby="trophiesHeading">
+    <div class="achievements-trophies__header">
+      <div>
+        <h2 id="trophiesHeading">Achievements</h2>
+        <p class="achievements-trophies__lead">Goals unlocked across every leaderboard.</p>
+      </div>
+      <p id="achievementProgress" class="achievements-trophies__count" role="status" aria-live="polite"></p>
+    </div>
+    <ul id="achievementList" class="achievements-trophies__list" role="list"></ul>
+  </section>
+
   <section class="achievements-management" aria-labelledby="managementHeading">
     <h2 id="managementHeading">Leaderboard Management</h2>
     <p class="achievements-management__intro">Export backups, import shared records, or clear the slate across every game.</p>
@@ -142,5 +153,7 @@ permalink: /projects/
     </div>
   </section>
 </div>
+
+<div id="achievementToastContainer" class="achievement-toast-container" aria-live="assertive" aria-atomic="true"></div>
 
 <script type="module" src="{{ '/projects/achievements.js' | relative_url }}"></script>

--- a/projects/index.html
+++ b/projects/index.html
@@ -4,6 +4,13 @@ permalink: /projects/
 ---
 
 <div class="achievements-page">
+  <nav class="achievements-nav" aria-label="Game navigation">
+    <a class="achievements-nav__link" href="{{ '/' | relative_url }}">&larr; Back to home</a>
+    <a class="achievements-nav__link" href="{{ '/projects/minesweeper/' | relative_url }}">Play Minesweeper</a>
+    <a class="achievements-nav__link" href="{{ '/projects/word-jumble/' | relative_url }}">Play Word Jumble</a>
+    <a class="achievements-nav__link" href="{{ '/projects/basketball/' | relative_url }}">Play Rapid Fire Free Throws</a>
+  </nav>
+
   <header class="achievements-hero">
     <div class="achievements-hero__art">
       <img src="{{ '/projects/minesweeper/flag.png' | relative_url }}" alt="Minesweeper flag icon" width="64" height="64" />
@@ -64,20 +71,17 @@ permalink: /projects/
           <p class="achievement-card__lead">Top scores from the free throw cannon.</p>
         </div>
       </header>
-      <dl class="achievement-stats" id="basketballStats">
-        <div class="achievement-stats__row">
-          <dt>Best Score</dt>
-          <dd id="basketballBest">—</dd>
-        </div>
-        <div class="achievement-stats__row">
-          <dt>High Score Date</dt>
-          <dd id="basketballBestDate">—</dd>
-        </div>
-        <div class="achievement-stats__row">
-          <dt>Runs Logged</dt>
-          <dd id="basketballRuns">0</dd>
-        </div>
-      </dl>
+      <table class="achievement-table">
+        <thead>
+          <tr>
+            <th scope="col">Level</th>
+            <th scope="col">Best Score</th>
+            <th scope="col">High Score Date</th>
+            <th scope="col">Runs Logged</th>
+          </tr>
+        </thead>
+        <tbody id="basketballSummary"></tbody>
+      </table>
       <p id="basketballEmpty" class="achievement-empty" hidden>Launch a volley of shots to begin charting history.</p>
     </article>
   </section>
@@ -86,15 +90,21 @@ permalink: /projects/
     <h2 id="managementHeading">Leaderboard Management</h2>
     <p class="achievements-management__intro">Export backups, import shared records, or clear the slate across every game.</p>
 
-    <div class="management-card" data-manage="minesweeper">
-      <h3>Minesweeper Leaderboards</h3>
+    <div class="management-card" data-manage="all">
+      <h3>All Game Data</h3>
+      <p>Download your complete game history or import a shared save to sync every leaderboard.</p>
       <div class="management-card__controls">
-        <button id="manageDownloadScores" type="button">Download Scores</button>
+        <button id="manageDownloadAll" type="button">Download All Scores</button>
         <label class="management-import">
-          <span>Import Scores</span>
-          <input type="file" id="manageImportScores" accept="application/json" />
+          <span>Import All Scores</span>
+          <input type="file" id="manageImportAll" accept="application/json" />
         </label>
       </div>
+      <p id="manageAllMessage" class="management-message" role="status" aria-live="polite"></p>
+    </div>
+
+    <div class="management-card" data-manage="minesweeper">
+      <h3>Minesweeper Leaderboards</h3>
       <div class="management-card__grid">
         <label>
           Mode

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,0 +1,136 @@
+---
+layout: default
+permalink: /projects/
+---
+
+<div class="achievements-page">
+  <header class="achievements-hero">
+    <div class="achievements-hero__art">
+      <img src="{{ '/projects/minesweeper/flag.png' | relative_url }}" alt="Minesweeper flag icon" width="64" height="64" />
+      <img src="{{ '/projects/word-jumble/assets/letters_small.png' | relative_url }}" alt="Word jumble tiles" width="64" height="64" />
+      <img src="{{ '/projects/basketball/assets/player.png' | relative_url }}" alt="Basketball player icon" width="64" height="64" />
+    </div>
+    <div class="achievements-hero__copy">
+      <h1>Alan's Game Zone Achievements</h1>
+      <p>Track your victories, puzzle streaks, and hoops dominance all in one place.</p>
+    </div>
+  </header>
+
+  <section class="achievements-grid" aria-label="Game progress summary">
+    <article class="achievement-card" data-game="minesweeper">
+      <header class="achievement-card__header">
+        <div class="achievement-card__icon">
+          <img src="{{ '/projects/minesweeper/smile.png' | relative_url }}" alt="Cheery minesweeper face" width="72" height="72" />
+        </div>
+        <div>
+          <h2>Minesweeper Triumphs</h2>
+          <p class="achievement-card__lead">Fastest human clear times per difficulty.</p>
+        </div>
+      </header>
+      <table class="achievement-table">
+        <thead>
+          <tr>
+            <th scope="col">Difficulty</th>
+            <th scope="col">Best Time</th>
+            <th scope="col">Wins</th>
+          </tr>
+        </thead>
+        <tbody id="minesweeperSummary"></tbody>
+      </table>
+      <p id="minesweeperEmpty" class="achievement-empty" hidden>You have not logged a win yet. The mines await!</p>
+    </article>
+
+    <article class="achievement-card" data-game="word-jumble">
+      <header class="achievement-card__header">
+        <div class="achievement-card__icon achievement-card__icon--glow">
+          <img src="{{ '/projects/word-jumble/assets/letters.png' | relative_url }}" alt="Exploding power letters" width="72" height="72" />
+        </div>
+        <div>
+          <h2>Word Jumble Power Plays</h2>
+          <p class="achievement-card__lead">Your mightiest anagram hauls.</p>
+        </div>
+      </header>
+      <ol id="wordJumbleHighlights" class="achievement-list"></ol>
+      <p id="wordJumbleEmpty" class="achievement-empty" hidden>Crack a few jumbles to reveal your signature words.</p>
+    </article>
+
+    <article class="achievement-card" data-game="basketball">
+      <header class="achievement-card__header">
+        <div class="achievement-card__icon achievement-card__icon--court">
+          <img src="{{ '/projects/basketball/assets/player.png' | relative_url }}" alt="Rapid fire shooter" width="72" height="72" />
+        </div>
+        <div>
+          <h2>Rapid Fire Records</h2>
+          <p class="achievement-card__lead">Top scores from the free throw cannon.</p>
+        </div>
+      </header>
+      <dl class="achievement-stats" id="basketballStats">
+        <div class="achievement-stats__row">
+          <dt>Best Score</dt>
+          <dd id="basketballBest">—</dd>
+        </div>
+        <div class="achievement-stats__row">
+          <dt>High Score Date</dt>
+          <dd id="basketballBestDate">—</dd>
+        </div>
+        <div class="achievement-stats__row">
+          <dt>Runs Logged</dt>
+          <dd id="basketballRuns">0</dd>
+        </div>
+      </dl>
+      <p id="basketballEmpty" class="achievement-empty" hidden>Launch a volley of shots to begin charting history.</p>
+    </article>
+  </section>
+
+  <section class="achievements-management" aria-labelledby="managementHeading">
+    <h2 id="managementHeading">Leaderboard Management</h2>
+    <p class="achievements-management__intro">Export backups, import shared records, or clear the slate across every game.</p>
+
+    <div class="management-card" data-manage="minesweeper">
+      <h3>Minesweeper Leaderboards</h3>
+      <div class="management-card__controls">
+        <button id="manageDownloadScores" type="button">Download Scores</button>
+        <label class="management-import">
+          <span>Import Scores</span>
+          <input type="file" id="manageImportScores" accept="application/json" />
+        </label>
+      </div>
+      <div class="management-card__grid">
+        <label>
+          Mode
+          <select id="manageMode">
+            <option value="human">Human</option>
+            <option value="auto">Auto</option>
+          </select>
+        </label>
+        <label>
+          Difficulty
+          <select id="manageDifficulty">
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="expert">Advanced</option>
+          </select>
+        </label>
+        <button id="manageClearSelected" type="button" class="management-clear">Clear Selected</button>
+      </div>
+      <button id="manageClearAll" type="button" class="management-clear management-clear--danger">Clear All Leaderboards</button>
+      <p id="manageMessage" class="management-message" role="status" aria-live="polite"></p>
+    </div>
+
+    <div class="management-card" data-manage="word-jumble">
+      <h3>Word Jumble Leaderboard</h3>
+      <p>Reset the POWER ANAGRAMS history if you want to start fresh.</p>
+      <button id="manageWordReset" type="button" class="management-clear">Clear Word Jumble Leaderboard</button>
+      <p id="manageWordMessage" class="management-message" role="status" aria-live="polite"></p>
+    </div>
+
+    <div class="management-card" data-manage="basketball">
+      <h3>Rapid Fire Free Throws Runs</h3>
+      <p>Remove stored run history and unlock progress for the basketball sim.</p>
+      <button id="manageBasketballReset" type="button" class="management-clear">Clear Basketball Runs</button>
+      <p id="manageBasketballMessage" class="management-message" role="status" aria-live="polite"></p>
+    </div>
+  </section>
+</div>
+
+<script type="module" src="{{ '/projects/achievements.js' | relative_url }}"></script>

--- a/projects/index.html
+++ b/projects/index.html
@@ -154,6 +154,8 @@ permalink: /projects/
   </section>
 </div>
 
+<script src="{{ '/projects/shared/achievements.js' | relative_url }}"></script>
+
 <div id="achievementToastContainer" class="achievement-toast-container" aria-live="assertive" aria-atomic="true"></div>
 
 <script type="module" src="{{ '/projects/achievements.js' | relative_url }}"></script>

--- a/projects/minesweeper/index.html
+++ b/projects/minesweeper/index.html
@@ -588,6 +588,7 @@
       <p>All images were crafted in Paint. Keep tinkering, keep sharing, keep dodging mines.</p>
     </div>
   </div>
+  <script src="../shared/achievements.js"></script>
   <script type="module" src="./scripts/main.js"></script>
 </body>
 </html>

--- a/projects/minesweeper/index.html
+++ b/projects/minesweeper/index.html
@@ -303,25 +303,6 @@
       padding-top: 12px;
       border-top: 1px solid rgba(15, 23, 42, 0.15);
     }
-    .score-controls {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      justify-content: center;
-      margin-bottom: 12px;
-    }
-    .import-label {
-      position: relative;
-      overflow: hidden;
-      display: inline-flex;
-      align-items: center;
-    }
-    .import-label input {
-      position: absolute;
-      inset: 0;
-      opacity: 0;
-      cursor: pointer;
-    }
     .score-groups {
       display: flex;
       flex-direction: column;
@@ -349,24 +330,12 @@
     .board-header {
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
       gap: 12px;
     }
     .board-header h3 {
       margin: 0;
       font-size: 1.05rem;
-    }
-    .clear-leaderboard {
-      padding: 4px 10px;
-      font-size: 0.85rem;
-      border: 1px solid rgba(148, 163, 184, 0.6);
-      border-radius: 999px;
-      background: rgba(241, 245, 249, 0.85);
-      color: #0f172a;
-      cursor: pointer;
-    }
-    .clear-leaderboard:hover {
-      background: rgba(226, 232, 240, 1);
     }
     .board-stats {
       font-size: 0.9rem;
@@ -611,13 +580,6 @@
       </div>
     </div>
     <div id="scoreboard">
-      <div class="score-controls">
-        <button id="downloadScores">Download Scores</button>
-        <label class="import-label">
-          <span>Import Scores</span>
-          <input type="file" id="importScores" accept="application/json">
-        </label>
-      </div>
       <div id="leaderboardContainer" class="score-groups"></div>
     </div>
     <section id="playerStats" class="player-stats"></section>

--- a/projects/minesweeper/scripts/ui.js
+++ b/projects/minesweeper/scripts/ui.js
@@ -56,6 +56,24 @@ const AUTO_STRATEGIES = {
 const DEFAULT_AUTO_STRATEGY = 'solver';
 const AUTO_RESTART_DELAY_MS = 1000;
 
+const DIFFICULTY_ACHIEVEMENTS = {
+  beginner: {
+    win: 'minesweeper-beginner-champion',
+    five: 'minesweeper-beginner-5',
+    ten: 'minesweeper-beginner-10',
+  },
+  intermediate: {
+    win: 'minesweeper-intermediate-champion',
+    five: 'minesweeper-intermediate-5',
+    ten: 'minesweeper-intermediate-10',
+  },
+  expert: {
+    win: 'minesweeper-advanced-champion',
+    five: 'minesweeper-advanced-5',
+    ten: 'minesweeper-advanced-10',
+  },
+};
+
 function imageForValue(value) {
   if (value === MINE) {
     return TILE_IMAGES.mine;
@@ -95,6 +113,9 @@ export class MinesweeperUI {
     this.autoRestartTimer = null;
     this._modalKeydownHandler = null;
     this._previouslyFocusedElement = null;
+    this.achievements = typeof window !== 'undefined' ? window.gameAchievements || null : null;
+    this._wrongFlaggedCells = new Set();
+    this._flagAccuracyInitialized = false;
   }
 
   init() {
@@ -105,6 +126,7 @@ export class MinesweeperUI {
     this._renderScoreboards();
     this._updateAutoUI();
     this._updateAutoRestartUI();
+    this._evaluateAllProgress({ silent: true });
     if (this.controlsModal) {
       this.controlsModal.setAttribute('aria-hidden', 'true');
     }
@@ -191,6 +213,14 @@ export class MinesweeperUI {
 
   _bindEvents() {
     this.faceImg.addEventListener('click', () => {
+      if (
+        this.achievements &&
+        this.game &&
+        this.game.revealedCount === 0 &&
+        this.game.status === GameStatus.READY
+      ) {
+        this._unlockAchievement('minesweeper-sun-early');
+      }
       this.mode = 'human';
       this._resetAutoState();
       this._selectDifficulty(this.currentDifficultyKey);
@@ -272,6 +302,7 @@ export class MinesweeperUI {
       button.classList.toggle('active', button.dataset.difficulty === key);
     });
     this.game = new MinesweeperGame(config.rows, config.cols, config.mines);
+    this._resetAchievementTracking();
     if (!preserveAuto) {
       this._resetAutoState();
       this.gameUsedAuto = false;
@@ -318,8 +349,9 @@ export class MinesweeperUI {
       return;
     }
     const { row, col } = this._eventToCoords(event);
+    const wasRevealed = this.game.revealed[row][col];
     const result = this.game.revealCell(row, col);
-    this._applyRevealResult(result);
+    this._applyRevealResult(result, { chordAttempt: wasRevealed });
   }
 
   _onCellContext(event) {
@@ -330,8 +362,7 @@ export class MinesweeperUI {
     const { row, col } = this._eventToCoords(event);
     const result = this.game.toggleFlag(row, col);
     if (result.changed) {
-      this._setTileState(row, col, result.flagged ? 'flagged' : 'hidden');
-      this._updateCounts();
+      this._handleFlagChange(row, col, result.flagged);
       this._setFace(result.flagged ? 'glasses' : 'smug');
     }
   }
@@ -344,9 +375,12 @@ export class MinesweeperUI {
     };
   }
 
-  _applyRevealResult(result, { fromAuto = false, guessed = false } = {}) {
+  _applyRevealResult(result, { fromAuto = false, guessed = false, chordAttempt = false } = {}) {
     if (!result) {
       return;
+    }
+    if (this.game?.minesPlaced && !this._flagAccuracyInitialized) {
+      this._refreshFlagAccuracy();
     }
     result.revealed.forEach(cell => {
       if (cell.value === MINE) {
@@ -360,7 +394,13 @@ export class MinesweeperUI {
       this._startTimer();
     }
     this._updateTimerDisplay();
+    if (chordAttempt && result.action === 'reveal' && result.revealed.length > 0) {
+      this._unlockAchievement('minesweeper-chordmaster');
+    }
     if (result.action === 'mine') {
+      if (this._wrongFlaggedCells.size > 0) {
+        this._unlockAchievement('minesweeper-flag-oops');
+      }
       this._handleLoss({ fromAuto });
       return;
     }
@@ -376,18 +416,23 @@ export class MinesweeperUI {
     } else {
       this._setFace('smile');
     }
+    this._checkFlagBasedAchievements();
   }
 
   _handleLoss({ fromAuto = false } = {}) {
     this._stopTimer();
     this._setFace('frown');
     this._setStatus('You tripped a mine. The crowd gasps.');
+    if (fromAuto) {
+      this._unlockAchievement('minesweeper-auto-down');
+    }
     const difficultyConfig = this.difficulties[this.currentDifficultyKey];
     const difficultyLabel = difficultyConfig?.label ?? this.currentDifficultyKey;
     const leaderboardMode = this._getLeaderboardMode();
     const playerName = this._getResultName(leaderboardMode);
     this.scoreRepository.recordLoss(leaderboardMode, this.currentDifficultyKey, difficultyLabel, playerName);
     this._renderScoreboards();
+    this._evaluateMinesweeperProgress(this.currentDifficultyKey);
     for (let r = 0; r < this.game.rows; r += 1) {
       for (let c = 0; c < this.game.cols; c += 1) {
         if (this.game.field[r][c] === MINE && !this.game.revealed[r][c]) {
@@ -413,8 +458,140 @@ export class MinesweeperUI {
     const playerName = this._getResultName(leaderboardMode);
     this.scoreRepository.recordWin(leaderboardMode, this.currentDifficultyKey, difficultyLabel, seconds, playerName);
     this._renderScoreboards();
+    this._evaluateMinesweeperProgress(this.currentDifficultyKey);
     const resumeAuto = fromAuto || mode === 'auto' || this.autoRunning;
     this._scheduleAutoRestart({ resumeAuto });
+  }
+
+  _handleFlagChange(row, col, flagged) {
+    this._setTileState(row, col, flagged ? 'flagged' : 'hidden');
+    this._updateCounts();
+    this._trackFlagAchievements(row, col, flagged);
+  }
+
+  _trackFlagAchievements(row, col, flagged) {
+    if (!this.game || !this.achievements) {
+      return;
+    }
+    const key = `${row},${col}`;
+    if (flagged) {
+      if (this.game.revealedCount === 0 && this.game.status === GameStatus.READY) {
+        this._unlockAchievement('minesweeper-preemptive-flag');
+      }
+      if (this.game.minesPlaced) {
+        if (this.game.field[row][col] !== MINE) {
+          this._wrongFlaggedCells.add(key);
+        } else {
+          this._wrongFlaggedCells.delete(key);
+        }
+      }
+    } else {
+      this._wrongFlaggedCells.delete(key);
+    }
+    if (this.game.remainingMines < 0) {
+      this._unlockAchievement('minesweeper-flag-overflow');
+    }
+    this._checkFlagBasedAchievements();
+  }
+
+  _refreshFlagAccuracy() {
+    if (!this.game || !this.game.minesPlaced) {
+      return;
+    }
+    this._flagAccuracyInitialized = true;
+    this._wrongFlaggedCells.clear();
+    for (let r = 0; r < this.game.rows; r += 1) {
+      for (let c = 0; c < this.game.cols; c += 1) {
+        if (this.game.flagged[r][c] && this.game.field[r][c] !== MINE) {
+          this._wrongFlaggedCells.add(`${r},${c}`);
+        }
+      }
+    }
+    this._checkFlagBasedAchievements();
+  }
+
+  _countFlags() {
+    if (!this.game) {
+      return 0;
+    }
+    let count = 0;
+    for (let r = 0; r < this.game.rows; r += 1) {
+      for (let c = 0; c < this.game.cols; c += 1) {
+        if (this.game.flagged[r][c]) {
+          count += 1;
+        }
+      }
+    }
+    return count;
+  }
+
+  _checkFlagBasedAchievements() {
+    if (!this.achievements || !this.game) {
+      return;
+    }
+    const totalCells = this.game.rows * this.game.cols;
+    const flaggedCount = this._countFlags();
+    if (flaggedCount === totalCells && totalCells > 0) {
+      this._unlockAchievement('minesweeper-flag-all');
+    }
+    if (this.game.minesPlaced && this.game.totalMines > 0) {
+      if (flaggedCount === this.game.totalMines && this._wrongFlaggedCells.size === 0) {
+        this._unlockAchievement('minesweeper-land-mapper');
+      }
+      if (this.game.remainingMines < 0) {
+        this._unlockAchievement('minesweeper-flag-overflow');
+      }
+    }
+  }
+
+  _setAchievement(achievementId, unlocked, { silent = false } = {}) {
+    if (!this.achievements) {
+      return;
+    }
+    this.achievements.setStatus('minesweeper', achievementId, unlocked, { silent });
+  }
+
+  _unlockAchievement(achievementId, options = {}) {
+    this._setAchievement(achievementId, true, options);
+  }
+
+  _evaluateMinesweeperProgress(difficultyKey, { silent = false } = {}) {
+    if (!this.achievements) {
+      return;
+    }
+    const ids = DIFFICULTY_ACHIEVEMENTS[difficultyKey];
+    if (!ids) {
+      return;
+    }
+    const config = this.difficulties[difficultyKey];
+    const label = config?.label ?? difficultyKey;
+    const humanBoard = this.scoreRepository.getLeaderboard('human', difficultyKey, label);
+    const autoBoard = this.scoreRepository.getLeaderboard('auto', difficultyKey, label);
+    const wins = Number(humanBoard?.wins || 0) + Number(autoBoard?.wins || 0);
+    const losses = Number(humanBoard?.losses || 0) + Number(autoBoard?.losses || 0);
+    const totalGames = wins + losses;
+    const updateOptions = { silent };
+    this.achievements.setStatus('minesweeper', ids.win, wins > 0, updateOptions);
+    this.achievements.setStatus('minesweeper', ids.five, totalGames >= 5, updateOptions);
+    this.achievements.setStatus('minesweeper', ids.ten, totalGames >= 10, updateOptions);
+    let totalAutoLosses = 0;
+    Object.keys(this.difficulties).forEach(key => {
+      const keyLabel = this.difficulties[key]?.label ?? key;
+      const auto = this.scoreRepository.getLeaderboard('auto', key, keyLabel);
+      totalAutoLosses += Number(auto?.losses || 0);
+    });
+    this.achievements.setStatus('minesweeper', 'minesweeper-auto-down', totalAutoLosses > 0, updateOptions);
+  }
+
+  _evaluateAllProgress({ silent = false } = {}) {
+    Object.keys(this.difficulties).forEach(key => {
+      this._evaluateMinesweeperProgress(key, { silent });
+    });
+  }
+
+  _resetAchievementTracking() {
+    this._wrongFlaggedCells = new Set();
+    this._flagAccuracyInitialized = false;
   }
 
   _setTileState(row, col, state, value = null) {
@@ -511,6 +688,7 @@ export class MinesweeperUI {
       const text = await file.text();
       this.scoreRepository.mergeScores(text);
       this._renderScoreboards();
+      this._evaluateAllProgress({ silent: true });
       this._setStatus('Scores imported and merged. Leaderboard updated.');
     } catch (err) {
       this._setStatus('Import failed. That file gave me bad vibes.');
@@ -838,14 +1016,18 @@ export class MinesweeperUI {
         if (action.type === 'flag') {
           const result = this.game.toggleFlag(action.row, action.col);
           if (result.changed) {
-            this._setTileState(action.row, action.col, result.flagged ? 'flagged' : 'hidden');
-            this._updateCounts();
+            this._handleFlagChange(action.row, action.col, result.flagged);
           }
           return;
         }
         if (action.type === 'reveal') {
+          const wasRevealed = this.game.revealed[action.row][action.col];
           const outcome = this.game.revealCell(action.row, action.col);
-          this._applyRevealResult(outcome, { fromAuto: true, guessed: action.guess });
+          this._applyRevealResult(outcome, {
+            fromAuto: true,
+            guessed: action.guess,
+            chordAttempt: wasRevealed,
+          });
         }
       });
     } catch (error) {

--- a/projects/minesweeper/scripts/ui.js
+++ b/projects/minesweeper/scripts/ui.js
@@ -166,15 +166,6 @@ export class MinesweeperUI {
         titleEl.textContent = config.label;
         header.appendChild(titleEl);
 
-        const clearBtn = this.document.createElement('button');
-        clearBtn.type = 'button';
-        clearBtn.className = 'clear-leaderboard';
-        clearBtn.dataset.mode = sectionConfig.mode;
-        clearBtn.dataset.difficulty = difficultyKey;
-        clearBtn.dataset.label = config.label;
-        clearBtn.textContent = 'Clear';
-        header.appendChild(clearBtn);
-
         board.appendChild(header);
 
         const statsEl = this.document.createElement('div');
@@ -192,7 +183,6 @@ export class MinesweeperUI {
           titleEl,
           statsEl,
           listEl: list,
-          clearButton: clearBtn,
         });
       });
       this.scoreboardContainer.appendChild(section);
@@ -212,31 +202,14 @@ export class MinesweeperUI {
         this._selectDifficulty(button.dataset.difficulty);
       });
     });
-    this.downloadBtn.addEventListener('click', () => {
-      this._downloadScores();
-    });
-    this.importInput.addEventListener('change', event => {
-      this._importScores(event);
-    });
-    if (this.scoreboardContainer) {
-      this.scoreboardContainer.addEventListener('click', event => {
-        const target = event.target;
-        if (!target || typeof target.closest !== 'function') {
-          return;
-        }
-        const button = target.closest('.clear-leaderboard');
-        if (!button) {
-          return;
-        }
-        const { mode, difficulty, label } = button.dataset;
-        if (!mode || !difficulty) {
-          return;
-        }
-        const difficultyLabel = label ?? this.difficulties[difficulty]?.label ?? difficulty;
-        this.scoreRepository.clearLeaderboard(mode, difficulty, difficultyLabel);
-        this._renderScoreboards();
-        const modeLabel = mode === 'auto' ? 'Auto' : 'User';
-        this._setStatus(`${modeLabel} ${difficultyLabel} leaderboard cleared.`);
+    if (this.downloadBtn) {
+      this.downloadBtn.addEventListener('click', () => {
+        this._downloadScores();
+      });
+    }
+    if (this.importInput) {
+      this.importInput.addEventListener('change', event => {
+        this._importScores(event);
       });
     }
     if (this.autoStrategySelect) {
@@ -558,9 +531,6 @@ export class MinesweeperUI {
         const boardLabel = board.label ?? fallbackLabel;
         if (elements.titleEl) {
           elements.titleEl.textContent = boardLabel;
-        }
-        if (elements.clearButton) {
-          elements.clearButton.dataset.label = boardLabel;
         }
         const totalGames = board.wins + board.losses;
         const winRate = totalGames === 0 ? 0 : board.wins / totalGames;

--- a/projects/shared/achievements.js
+++ b/projects/shared/achievements.js
@@ -25,6 +25,93 @@
         description: 'Finish a rapid-fire run with a perfect goose egg—celebrate the art of missing every shot.',
       },
     ],
+    minesweeper: [
+      {
+        id: 'minesweeper-land-mapper',
+        name: 'Land Mine Mapper',
+        description: 'Flag every hidden mine on a single board without a single false alarm.',
+      },
+      {
+        id: 'minesweeper-sun-early',
+        name: 'Sun Dial Spin',
+        description: 'Tap the sun reset before revealing a single tile—fresh board, fresh start.',
+      },
+      {
+        id: 'minesweeper-preemptive-flag',
+        name: 'Premonition Planter',
+        description: 'Drop your first flag before uncovering any tiles.',
+      },
+      {
+        id: 'minesweeper-flag-oops',
+        name: 'Flagged and Fragged',
+        description: 'Trigger a mine while a bogus flag still waves over a safe square.',
+      },
+      {
+        id: 'minesweeper-auto-down',
+        name: 'Autopilot Flameout',
+        description: 'Watch the AI crash and burn with a loss in auto pilot mode.',
+      },
+      {
+        id: 'minesweeper-beginner-champion',
+        name: 'Beginner’s Bragging Rights',
+        description: 'Win a Beginner board at least once.',
+      },
+      {
+        id: 'minesweeper-beginner-5',
+        name: 'Beginner Binge',
+        description: 'Finish five Beginner boards, win or lose.',
+      },
+      {
+        id: 'minesweeper-beginner-10',
+        name: 'Beginner Marathon',
+        description: 'Finish ten Beginner boards, no matter the outcome.',
+      },
+      {
+        id: 'minesweeper-intermediate-champion',
+        name: 'Intermediate Instincts',
+        description: 'Conquer an Intermediate board at least once.',
+      },
+      {
+        id: 'minesweeper-intermediate-5',
+        name: 'Intermediate Itinerary',
+        description: 'Wrap up five Intermediate games of Minesweeper.',
+      },
+      {
+        id: 'minesweeper-intermediate-10',
+        name: 'Intermediate Ironperson',
+        description: 'Complete ten Intermediate sessions, regardless of outcome.',
+      },
+      {
+        id: 'minesweeper-advanced-champion',
+        name: 'Advanced Avalanche',
+        description: 'Defuse every mine on an Advanced board for a win.',
+      },
+      {
+        id: 'minesweeper-advanced-5',
+        name: 'Advanced Adventurer',
+        description: 'Finish five Advanced boards from start to finish.',
+      },
+      {
+        id: 'minesweeper-advanced-10',
+        name: 'Advanced Marathoner',
+        description: 'See ten Advanced boards through to the end.',
+      },
+      {
+        id: 'minesweeper-flag-overflow',
+        name: 'Flag Frenzy',
+        description: 'Plant more flags than there are mines on the board.',
+      },
+      {
+        id: 'minesweeper-flag-all',
+        name: 'Wallpaper of Warnings',
+        description: 'Cover every single tile with a flag, just in case.',
+      },
+      {
+        id: 'minesweeper-chordmaster',
+        name: 'Chord Conductor',
+        description: 'Reveal a cluster by chording on a number with all adjacent mines flagged.',
+      },
+    ],
   };
 
   let memoryState = loadState();

--- a/projects/shared/achievements.js
+++ b/projects/shared/achievements.js
@@ -1,0 +1,327 @@
+(function (global) {
+  'use strict';
+
+  const STORAGE_KEY = 'game_zone_achievements_store_v1';
+  const TOAST_DURATION_MS = 5000;
+  const STYLE_ELEMENT_ID = 'game-achievement-toast-styles';
+
+  const CATALOG = {
+    'word-jumble': [
+      {
+        id: 'word-aeprs',
+        name: 'aeprs creepers!',
+        description: "Log the chilling letter combo 'aeprs' in your Word Jumble history.",
+      },
+    ],
+    basketball: [
+      {
+        id: 'basketball-curry-hurry',
+        name: 'Curry hurry!',
+        description: 'Drop at least 180 points on Level 2 to prove a blistering 90% free throw percentage.',
+      },
+      {
+        id: 'basketball-zero-hero',
+        name: 'Goose Egg Gala!',
+        description: 'Finish a rapid-fire run with a perfect goose egg—celebrate the art of missing every shot.',
+      },
+    ],
+  };
+
+  let memoryState = loadState();
+
+  const toastQueue = [];
+  let activeToastTimer = null;
+  let domReady = typeof document !== 'undefined' && document.readyState !== 'loading';
+
+  if (!domReady && typeof document !== 'undefined') {
+    document.addEventListener(
+      'DOMContentLoaded',
+      () => {
+        domReady = true;
+        if (toastQueue.length > 0 && !activeToastTimer) {
+          showNextToast();
+        }
+      },
+      { once: true }
+    );
+  }
+
+  function loadState() {
+    if (!global.localStorage) {
+      return { games: {} };
+    }
+    try {
+      const raw = global.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return { games: {} };
+      }
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || typeof parsed.games !== 'object') {
+        return { games: {} };
+      }
+      return { games: parsed.games };
+    } catch (error) {
+      return { games: {} };
+    }
+  }
+
+  function saveState(state) {
+    if (!global.localStorage) {
+      return;
+    }
+    try {
+      global.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      // ignore persistence failures
+    }
+  }
+
+  function getCatalogForGame(gameId) {
+    return Array.isArray(CATALOG[gameId]) ? CATALOG[gameId] : [];
+  }
+
+  function getAchievementMeta(gameId, achievementId) {
+    return getCatalogForGame(gameId).find(item => item.id === achievementId) || null;
+  }
+
+  function getAchievementState(gameId, achievementId) {
+    if (!memoryState.games[gameId]) {
+      memoryState.games[gameId] = {};
+    }
+    if (!memoryState.games[gameId][achievementId]) {
+      memoryState.games[gameId][achievementId] = { unlocked: false, unlockedAt: null };
+    }
+    return memoryState.games[gameId][achievementId];
+  }
+
+  function ensureGameDefaults(gameId) {
+    const catalog = getCatalogForGame(gameId);
+    if (catalog.length === 0) {
+      return;
+    }
+    let changed = false;
+    catalog.forEach(meta => {
+      const gameState = memoryState.games[gameId] || (memoryState.games[gameId] = {});
+      const hadEntry = Object.prototype.hasOwnProperty.call(gameState, meta.id);
+      const entry = getAchievementState(gameId, meta.id);
+      if (!hadEntry) {
+        changed = true;
+      }
+      if (typeof entry.unlocked !== 'boolean' || (entry.unlocked && typeof entry.unlockedAt !== 'string')) {
+        entry.unlocked = Boolean(entry.unlocked);
+        entry.unlockedAt = entry.unlocked ? entry.unlockedAt || new Date().toISOString() : null;
+        changed = true;
+      }
+    });
+    if (changed) {
+      saveState(memoryState);
+    }
+  }
+
+  Object.keys(CATALOG).forEach(ensureGameDefaults);
+
+  function setStatus(gameId, achievementId, unlocked, options = {}) {
+    const meta = getAchievementMeta(gameId, achievementId);
+    if (!meta) {
+      return false;
+    }
+    const silent = Boolean(options.silent);
+    const entry = getAchievementState(gameId, achievementId);
+    const nextValue = Boolean(unlocked);
+    if (entry.unlocked === nextValue) {
+      return entry.unlocked;
+    }
+    entry.unlocked = nextValue;
+    entry.unlockedAt = nextValue ? new Date().toISOString() : null;
+    saveState(memoryState);
+    if (nextValue && !silent) {
+      enqueueToast(meta);
+    }
+    return entry.unlocked;
+  }
+
+  function resetGame(gameId) {
+    const catalog = getCatalogForGame(gameId);
+    if (catalog.length === 0) {
+      return;
+    }
+    let changed = false;
+    catalog.forEach(meta => {
+      const entry = getAchievementState(gameId, meta.id);
+      if (entry.unlocked || entry.unlockedAt) {
+        entry.unlocked = false;
+        entry.unlockedAt = null;
+        changed = true;
+      }
+    });
+    if (changed) {
+      saveState(memoryState);
+    }
+  }
+
+  function isUnlocked(gameId, achievementId) {
+    const entry = getAchievementState(gameId, achievementId);
+    return Boolean(entry.unlocked);
+  }
+
+  function getAllStates() {
+    const states = [];
+    Object.keys(CATALOG).forEach(gameId => {
+      getCatalogForGame(gameId).forEach(meta => {
+        const entry = getAchievementState(gameId, meta.id);
+        states.push({
+          gameId,
+          id: meta.id,
+          name: meta.name,
+          description: meta.description,
+          unlocked: Boolean(entry.unlocked),
+          unlockedAt: entry.unlocked ? entry.unlockedAt : null,
+        });
+      });
+    });
+    return states;
+  }
+
+  function getCatalog() {
+    const clone = {};
+    Object.keys(CATALOG).forEach(gameId => {
+      clone[gameId] = getCatalogForGame(gameId).map(item => ({ ...item }));
+    });
+    return clone;
+  }
+
+  function ensureToastStyles() {
+    if (typeof document === 'undefined' || document.getElementById(STYLE_ELEMENT_ID)) {
+      return;
+    }
+    const style = document.createElement('style');
+    style.id = STYLE_ELEMENT_ID;
+    style.textContent = `
+.achievement-toast-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 4vh 1rem 1rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  z-index: 1000;
+}
+
+.achievement-toast-container.is-active {
+  opacity: 1;
+}
+
+.achievement-toast {
+  max-width: min(420px, 92vw);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(14, 116, 144, 0.92));
+  color: #fff;
+  padding: 1.1rem 1.35rem;
+  border-radius: 20px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.32);
+  border: 1px solid rgba(191, 219, 254, 0.4);
+  backdrop-filter: blur(12px);
+}
+
+.achievement-toast__eyebrow {
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.achievement-toast__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.4rem;
+}
+
+.achievement-toast__body {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.92);
+}
+`;
+    document.head.appendChild(style);
+  }
+
+  function ensureToastContainer() {
+    if (typeof document === 'undefined' || !document.body) {
+      return null;
+    }
+    let container = document.getElementById('achievementToastContainer');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'achievementToastContainer';
+      container.className = 'achievement-toast-container';
+      container.setAttribute('aria-live', 'assertive');
+      container.setAttribute('aria-atomic', 'true');
+      document.body.appendChild(container);
+    }
+    ensureToastStyles();
+    return container;
+  }
+
+  function enqueueToast(meta) {
+    toastQueue.push(meta);
+    if (domReady) {
+      showNextToast();
+    }
+  }
+
+  function showNextToast() {
+    if (activeToastTimer || toastQueue.length === 0) {
+      return;
+    }
+    const container = ensureToastContainer();
+    if (!container) {
+      return;
+    }
+
+    const achievement = toastQueue.shift();
+    container.innerHTML = '';
+    container.classList.add('is-active');
+
+    const toast = document.createElement('div');
+    toast.className = 'achievement-toast';
+
+    const eyebrow = document.createElement('p');
+    eyebrow.className = 'achievement-toast__eyebrow';
+    eyebrow.textContent = 'Achievement unlocked!';
+
+    const title = document.createElement('p');
+    title.className = 'achievement-toast__title';
+    title.textContent = achievement.name;
+
+    const description = document.createElement('p');
+    description.className = 'achievement-toast__body';
+    description.textContent = achievement.description;
+
+    toast.appendChild(eyebrow);
+    toast.appendChild(title);
+    toast.appendChild(description);
+    container.appendChild(toast);
+
+    activeToastTimer = global.setTimeout(() => {
+      activeToastTimer = null;
+      if (toastQueue.length === 0) {
+        container.classList.remove('is-active');
+        container.innerHTML = '';
+      }
+      showNextToast();
+    }, TOAST_DURATION_MS);
+  }
+
+  global.gameAchievements = {
+    getCatalog,
+    getAllStates,
+    isUnlocked,
+    setStatus,
+    resetGame,
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/projects/word-jumble/index.html
+++ b/projects/word-jumble/index.html
@@ -8,6 +8,7 @@
 	characters that you type into the box, but in different orders">
 	<meta name="keywords" content="Word puzzle, Javascript, learn coding">
 	<meta name="author" content="Alan Rominger">
+        <script src="../shared/achievements.js"></script>
 <script type="text/javascript" src="key.js"></script>
 <script>
 function clearField() {
@@ -170,6 +171,9 @@ function updateLeaderboard(word, count) {
                 return a.word.localeCompare(b.word);
         });
         saveLeaderboard(entries.slice(0, 50));
+        if (normalized === "aeprs" && window.gameAchievements) {
+                window.gameAchievements.setStatus("word-jumble", "word-aeprs", true);
+        }
         renderLeaderboard();
 }
 

--- a/projects/word-jumble/index.html
+++ b/projects/word-jumble/index.html
@@ -268,6 +268,12 @@ p {
     border-radius: 12px;
     box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
 }
+.other-list {
+    margin: 0 0 12px 24px;
+}
+.other-list li {
+    margin: 4px 0;
+}
 .power-zone {
     margin-top: 16px;
     padding: 12px;
@@ -383,13 +389,17 @@ p {
 	<p><input type="text" id="userWord" onkeyup="closestWord()" value=""/></p>
 	<p>Unscrambling attempt: </p>
 	<div id="showIt" class="mainOut"></div>
+        <p>Other possibilities: </p>
+        <ul class="other-list">
+                <li><div id="show1" class="outField"></div></li>
+                <li><div id="show2" class="outField"></div></li>
+                <li><div id="show3" class="outField"></div></li>
+                <li><div id="show4" class="outField"></div></li>
+        </ul>
+
         <div class="power-zone">
                 <h2 class="power-heading">POWER ANAGRAMS</h2>
                 <ul class="power-list">
-                        <li class="power-item"><div id="show1" class="outField"></div></li>
-                        <li class="power-item"><div id="show2" class="outField"></div></li>
-                        <li class="power-item"><div id="show3" class="outField"></div></li>
-                        <li class="power-item"><div id="show4" class="outField"></div></li>
                         <li class="power-item power-item--charged"><div id="show5" class="outField"></div></li>
                         <li class="power-item power-item--hyper"><div id="show6" class="outField"></div></li>
                 </ul>

--- a/projects/word-jumble/index.html
+++ b/projects/word-jumble/index.html
@@ -24,8 +24,10 @@ function closestWord() {
 	var userIn;
 	var sortIn;
 	var i,j,xLen,foundFlag;
-	var dictWord;
-	var theHaul = ["","","","",""];
+        var dictWord;
+        var theHaul = ["","","","","","",""];
+        var showIds = ["show1","show2","show3","show4","show5","show6"];
+        var overNineThousand = document.getElementById("over9000");
 	userIn = document.getElementById("userWord").value;
 	userIn = userIn.toLowerCase();
 	document.getElementById("userWord").value = userIn;
@@ -53,9 +55,9 @@ function closestWord() {
 			if (transformWord(dictWord)==sortIn) {
 				theHaul[foundFlag] = dictWord;
 				foundFlag += 1;
-				if (foundFlag>4) {
-					break;
-				}
+                                if (foundFlag>6) {
+                                        break;
+                                }
 			}
 		}
 	}
@@ -66,32 +68,31 @@ function closestWord() {
 	} else {
 		document.getElementById("showIt").innerHTML=theHaul[0];
 	}
-	if (foundFlag > 1) {
-		document.getElementById("show1").innerHTML=theHaul[1];
-	} else {
-		document.getElementById("show1").innerHTML=" - ";
-	}
-	if (foundFlag > 2) {
-		document.getElementById("show2").innerHTML=theHaul[2];
-	} else {
-		document.getElementById("show2").innerHTML=" - ";
-	}
-	if (foundFlag > 3) {
-		document.getElementById("show3").innerHTML=theHaul[3];
-	} else {
-		document.getElementById("show3").innerHTML=" - ";
-	}
-	if (foundFlag > 4) {
-		document.getElementById("show4").innerHTML=theHaul[4];
-	} else {
-		document.getElementById("show4").innerHTML=" - ";
-	}
+        for (var slot = 0; slot < showIds.length; slot++) {
+                var field = document.getElementById(showIds[slot]);
+                if (!field) {
+                        continue;
+                }
+                if (foundFlag > slot + 1) {
+                        field.innerHTML = theHaul[slot + 1];
+                } else {
+                        field.innerHTML = " - ";
+                }
+        }
+        if (overNineThousand) {
+                if (foundFlag > showIds.length) {
+                        overNineThousand.className = "over-9000 over-9000--active";
+                } else {
+                        overNineThousand.className = "over-9000";
+                }
+        }
+        updateLeaderboard(userIn, foundFlag);
 }
 function transformWord(inWord) {
-	var outWord = "";
-	var charLow;
-	var inWord2;
-	inWord2 = inWord;
+        var outWord = "";
+        var charLow;
+        var inWord2;
+        inWord2 = inWord;
 	var j,k,l;
 	for (j=0; j<inWord.length; j++) {
 		l=0;
@@ -104,9 +105,121 @@ function transformWord(inWord) {
 		}
 		outWord = outWord + charLow;
 		inWord2 = inWord2.substring(0,l)+inWord2.substring(l+1,inWord2.length);
-	}
-	return outWord;
+        }
+        return outWord;
 }
+
+var leaderboardKey = "word_jumble_power_stats_v1";
+
+function loadLeaderboard() {
+        try {
+                var payload = window.localStorage.getItem(leaderboardKey);
+                if (!payload) {
+                        return [];
+                }
+                var data = JSON.parse(payload);
+                if (!Array.isArray(data)) {
+                        return [];
+                }
+                return data;
+        } catch (err) {
+                return [];
+        }
+}
+
+function saveLeaderboard(entries) {
+        try {
+                window.localStorage.setItem(leaderboardKey, JSON.stringify(entries));
+        } catch (err) {
+                // ignore storage failures
+        }
+}
+
+function updateLeaderboard(word, count) {
+        if (!word || count <= 0) {
+                renderLeaderboard();
+                return;
+        }
+        var normalized = word.trim().toLowerCase();
+        if (!normalized) {
+                renderLeaderboard();
+                return;
+        }
+        var entries = loadLeaderboard();
+        var timestamp = new Date().toISOString();
+        var found = false;
+        for (var i = 0; i < entries.length; i++) {
+                if (entries[i].word === normalized) {
+                        entries[i].count = Math.max(entries[i].count || 0, count);
+                        entries[i].display = word;
+                        entries[i].updatedAt = timestamp;
+                        found = true;
+                        break;
+                }
+        }
+        if (!found) {
+                entries.push({ word: normalized, display: word, count: count, updatedAt: timestamp });
+        }
+        entries.sort(function(a, b) {
+                if ((b.count || 0) !== (a.count || 0)) {
+                        return (b.count || 0) - (a.count || 0);
+                }
+                if (b.updatedAt !== a.updatedAt) {
+                        return (b.updatedAt || "").localeCompare(a.updatedAt || "");
+                }
+                return a.word.localeCompare(b.word);
+        });
+        saveLeaderboard(entries.slice(0, 50));
+        renderLeaderboard();
+}
+
+function renderLeaderboard() {
+        var body = document.getElementById("leaderboardBody");
+        if (!body) {
+                return;
+        }
+        var entries = loadLeaderboard().slice();
+        entries.sort(function(a, b) {
+                if ((b.count || 0) !== (a.count || 0)) {
+                        return (b.count || 0) - (a.count || 0);
+                }
+                if ((b.updatedAt || "") !== (a.updatedAt || "")) {
+                        return (b.updatedAt || "").localeCompare(a.updatedAt || "");
+                }
+                return a.word.localeCompare(b.word);
+        });
+        var topEntries = entries.slice(0, 10);
+        body.innerHTML = "";
+        if (topEntries.length === 0) {
+                var row = document.createElement("tr");
+                var cell = document.createElement("td");
+                cell.colSpan = 3;
+                cell.className = "leaderboard-empty";
+                cell.textContent = "No anagram streaks logged yet.";
+                row.appendChild(cell);
+                body.appendChild(row);
+                return;
+        }
+        for (var i = 0; i < topEntries.length; i++) {
+                var entry = topEntries[i];
+                var rank = i + 1;
+                var tr = document.createElement("tr");
+                var rankCell = document.createElement("td");
+                rankCell.textContent = rank;
+                var wordCell = document.createElement("td");
+                wordCell.textContent = entry.display || entry.word;
+                var countCell = document.createElement("td");
+                countCell.textContent = entry.count || 0;
+                tr.appendChild(rankCell);
+                tr.appendChild(wordCell);
+                tr.appendChild(countCell);
+                body.appendChild(tr);
+        }
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+        renderLeaderboard();
+});
 </script>
 <style>
 body {
@@ -155,6 +268,108 @@ p {
     border-radius: 12px;
     box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
 }
+.power-zone {
+    margin-top: 16px;
+    padding: 12px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(0, 170, 255, 0.12), rgba(0, 120, 255, 0.05));
+    border: 1px solid rgba(0, 85, 170, 0.2);
+}
+
+.power-heading {
+    margin: 0 0 8px;
+    text-align: center;
+    font-size: 1.1rem;
+    letter-spacing: 0.08em;
+    color: #0b4da2;
+}
+
+.power-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 6px;
+}
+
+.power-item {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 28px;
+    border-radius: 999px;
+    background: rgba(0, 102, 204, 0.08);
+    color: #004080;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.power-item--charged {
+    background: rgba(255, 166, 0, 0.14);
+    color: #b45309;
+    box-shadow: inset 0 0 0 2px rgba(255, 166, 0, 0.2);
+}
+
+.power-item--hyper {
+    background: rgba(220, 38, 38, 0.16);
+    color: #991b1b;
+    box-shadow: inset 0 0 0 2px rgba(220, 38, 38, 0.24);
+}
+
+.over-9000 {
+    margin-top: 10px;
+    text-align: center;
+    font-weight: 700;
+    color: #a3a3a3;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.over-9000--active {
+    color: #ff1a1a;
+    transform: scale(1.08);
+}
+
+.leaderboard {
+    margin-top: 24px;
+    padding: 16px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 12px 24px rgba(0, 40, 80, 0.12);
+}
+
+.leaderboard h2 {
+    margin-top: 0;
+    text-align: center;
+    font-size: 1.2rem;
+    color: #0b4da2;
+}
+
+.leaderboard table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 12px;
+}
+
+.leaderboard th,
+.leaderboard td {
+    padding: 8px 10px;
+    text-align: left;
+    border-bottom: 1px solid rgba(11, 77, 162, 0.15);
+}
+
+.leaderboard th {
+    font-size: 0.85rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #0b4da2;
+}
+
+.leaderboard-empty {
+    text-align: center;
+    color: #6b7280;
+    font-style: italic;
+}
 </style>
 </head>
 
@@ -168,13 +383,18 @@ p {
 	<p><input type="text" id="userWord" onkeyup="closestWord()" value=""/></p>
 	<p>Unscrambling attempt: </p>
 	<div id="showIt" class="mainOut"></div>
-	<p>Other possibilities: </p>
-        <p><ul>
-                <li><div id="show1" class="outField"></div></li>
-                <li><div id="show2" class="outField"></div></li>
-                <li><div id="show3" class="outField"></div></li>
-                <li><div id="show4" class="outField"></div></li>
-        </ul></p>
+        <div class="power-zone">
+                <h2 class="power-heading">POWER ANAGRAMS</h2>
+                <ul class="power-list">
+                        <li class="power-item"><div id="show1" class="outField"></div></li>
+                        <li class="power-item"><div id="show2" class="outField"></div></li>
+                        <li class="power-item"><div id="show3" class="outField"></div></li>
+                        <li class="power-item"><div id="show4" class="outField"></div></li>
+                        <li class="power-item power-item--charged"><div id="show5" class="outField"></div></li>
+                        <li class="power-item power-item--hyper"><div id="show6" class="outField"></div></li>
+                </ul>
+                <p id="over9000" class="over-9000">It's over 9000</p>
+        </div>
 
         <img
             src="assets/letters.png"
@@ -204,13 +424,28 @@ p {
 	 
 	 <p>Various parts of this project required:
 	 
-	 <a href="http://www.w3schools.com/xml/xml_http.asp">Javascript XMLHttpRequest</a> and
-	 <a href="https://msdn.microsoft.com/en-us/library/b0zbh7b6%28v=vs.110%29.aspx">C# comparator overrides</a>.
-	 Also, I discovered that the automatic C# list sorter can alphabetize a 
-	 dictionary in about .2 seconds whereas the brute force approach takes 1 hour.
-	  I knew that sorting can be heavily optimized but I was still surprised by
-	  the magnitude of the difference.
-	 </p>
+         <a href="http://www.w3schools.com/xml/xml_http.asp">Javascript XMLHttpRequest</a> and
+         <a href="https://msdn.microsoft.com/en-us/library/b0zbh7b6%28v=vs.110%29.aspx">C# comparator overrides</a>.
+         Also, I discovered that the automatic C# list sorter can alphabetize a
+         dictionary in about .2 seconds whereas the brute force approach takes 1 hour.
+          I knew that sorting can be heavily optimized but I was still surprised by
+          the magnitude of the difference.
+         </p>
+
+        <section class="leaderboard" aria-labelledby="leaderboardTitle">
+                <h2 id="leaderboardTitle">Anagram Leaderboard</h2>
+                <p>Top 10 words ranked by the number of valid anagrams discovered.</p>
+                <table>
+                        <thead>
+                                <tr>
+                                        <th scope="col">Rank</th>
+                                        <th scope="col">Word</th>
+                                        <th scope="col">Anagrams</th>
+                                </tr>
+                        </thead>
+                        <tbody id="leaderboardBody"></tbody>
+                </table>
+        </section>
 
 </div>
 


### PR DESCRIPTION
## Summary
- Expand the word jumble "POWER ANAGRAMS" section with two extra slots, a dramatic overflow indicator, and a persistent top-10 leaderboard backed by local storage.
- Remove leaderboard management UI from Minesweeper and adjust its scripts so the game focuses on play while still rendering scores cleanly.
- Introduce a projects achievements hub with shared leaderboard management controls, cross-game summaries, refreshed homepage linking, and supporting styles and scripts.

## Testing
- bundle exec jekyll serve --livereload --watch --host 0.0.0.0 --port 4000 *(fails: jekyll executable missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de86acb7508322bc8caf8fb3069876