### PR TITLE
Refresh achievements hub navigation and add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm install

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -277,6 +277,40 @@
     }
 }
 
+.home-links--profiles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: $spacing-unit / 3;
+
+    > li {
+        margin: 0;
+    }
+}
+
+.home-profile-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    color: #0f172a;
+    text-decoration: none;
+    background: linear-gradient(135deg, rgba(96, 165, 250, 0.18), rgba(56, 189, 248, 0.28));
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(37, 99, 235, 0.25);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    white-space: nowrap;
+}
+
+.home-profile-link:hover,
+.home-profile-link:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 28px rgba(37, 99, 235, 0.22);
+    text-decoration: none;
+}
+
 .home-links--games > li {
     display: flex;
     align-items: center;
@@ -500,6 +534,34 @@
 .achievement-card__lead {
     margin: 0;
     color: $grey-color;
+}
+
+.achievement-card__title-link {
+    color: inherit;
+    text-decoration: none;
+    position: relative;
+    padding-bottom: 0.15rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.achievement-card__title-link::after {
+    content: '↗';
+    font-size: 0.8em;
+    opacity: 0.7;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.achievement-card__title-link:hover,
+.achievement-card__title-link:focus {
+    color: #1d4ed8;
+}
+
+.achievement-card__title-link:hover::after,
+.achievement-card__title-link:focus::after {
+    opacity: 1;
+    transform: translateX(2px) translateY(-1px);
 }
 
 .u-screen-reader-text {

--- a/about.md
+++ b/about.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: About
+title: About Jekyll Theme
 permalink: /about/
 ---
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@ layout: default
 
 <div class="home">
   <header class="home-intro">
-    <h1 class="page-heading">AlanCoding (github) homepage</h1>
     <p class="home-lede">
       This is my static-files only web presence (I have shut down a few original hosted services).
       Some content is stuff I made while doing the Iron Yard in 2015, and it's still here.
@@ -18,7 +17,7 @@ layout: default
   <section class="home-section">
     <h2 class="section-heading">Alan's Game Zone</h2>
     <p class="section-description">
-      I hand-wrote the minesweeper and work-jumble originally.
+      I hand-wrote the Land Mine Mapper and word jumble originally.
       Then I started to use AI to supercharge my games here, ever since Codex got good.
       Whenver the AI writes text it's totally cringe, which you can see in some of the "blog" posts below.
     </p>
@@ -30,12 +29,12 @@ layout: default
         <img
           class="home-game-icon"
           src="{{ '/projects/minesweeper/flag.png' | relative_url }}"
-          alt="Minesweeper flag icon"
+          alt="Land Mine Mapper flag icon"
           width="48"
           height="48"
         />
         <div class="home-game-meta">
-          <a href="{{ '/projects/minesweeper/' | relative_url }}">Minesweeper</a>
+          <a href="{{ '/projects/minesweeper/' | relative_url }}">Land Mine Mapper</a>
           <p class="home-game-description">Classic mine-clearing puzzle with custom board sizes.</p>
         </div>
       </li>
@@ -74,21 +73,11 @@ layout: default
 
   <section class="home-section">
     <h2 class="section-heading">Profiles</h2>
-    <ul class="home-links">
-      <li><a href="https://www.linkedin.com/in/alan-rominger-40236518">LinkedIn</a></li>
-      <li><a href="https://github.com/AlanCoding">GitHub</a></li>
-      <li><a href="http://physics.stackexchange.com/users/1255/alan-rominger">Physics Stack Exchange</a></li>
-      <li><a href="https://www.inaturalist.org/people/8281527">INaturalist</a></li>
-    </ul>
-  </section>
-
-  <section class="home-section">
-    <h2 class="section-heading">More Links Coming Soon</h2>
-    <ul class="home-links home-placeholders">
-      <li>
-        <img class="under-construction-icon" src="{{ '/assets/img/under-construction-missing.gif' | relative_url }}" alt="Under construction icon placeholder">
-        <span>Future project slot &mdash; pardon the digital dust.</span>
-      </li>
+    <ul class="home-links home-links--profiles">
+      <li><a class="home-profile-link" href="https://www.linkedin.com/in/alan-rominger-40236518">LinkedIn</a></li>
+      <li><a class="home-profile-link" href="https://github.com/AlanCoding">GitHub</a></li>
+      <li><a class="home-profile-link" href="http://physics.stackexchange.com/users/1255/alan-rominger">Physics Stack Exchange</a></li>
+      <li><a class="home-profile-link" href="https://www.inaturalist.org/people/8281527">INaturalist</a></li>
     </ul>
   </section>
 

--- a/projects/achievements.js
+++ b/projects/achievements.js
@@ -1,6 +1,6 @@
 import { ScoreRepository, formatSeconds } from './minesweeper/scripts/scoreboard.js';
 
-const MINESWEEPER_DIFFICULTIES = [
+const LAND_MINE_MAPPER_DIFFICULTIES = [
   { key: 'beginner', label: 'Beginner' },
   { key: 'intermediate', label: 'Intermediate' },
   { key: 'expert', label: 'Advanced' },
@@ -15,7 +15,7 @@ const DATA_EXPORT_VERSION = 1;
 const ACHIEVEMENT_GAME_LABELS = {
   'word-jumble': 'Word Jumble',
   basketball: 'Rapid Fire Free Throws',
-  minesweeper: 'Minesweeper',
+  minesweeper: 'Land Mine Mapper',
 };
 
 function renderMinesweeperSummary(repo) {
@@ -26,7 +26,7 @@ function renderMinesweeperSummary(repo) {
   }
   tbody.innerHTML = '';
   let hasWin = false;
-  MINESWEEPER_DIFFICULTIES.forEach(difficulty => {
+  LAND_MINE_MAPPER_DIFFICULTIES.forEach(difficulty => {
     const board = repo.getLeaderboard('human', difficulty.key, difficulty.label);
     const bestEntry = Array.isArray(board.entries) && board.entries.length > 0 ? board.entries[0] : null;
     if (bestEntry) {
@@ -216,7 +216,7 @@ function collectAchievementFacts() {
     difficulties: {},
     totalAutoLosses: 0,
   };
-  MINESWEEPER_DIFFICULTIES.forEach(difficulty => {
+  LAND_MINE_MAPPER_DIFFICULTIES.forEach(difficulty => {
     const humanBoard = leaderboards.human?.[difficulty.key] ?? { wins: 0, losses: 0 };
     const autoBoard = leaderboards.auto?.[difficulty.key] ?? { wins: 0, losses: 0 };
     const wins = Number(humanBoard.wins || 0) + Number(autoBoard.wins || 0);
@@ -386,7 +386,8 @@ function setupMinesweeperManagement(repo) {
     clearSelectedBtn.addEventListener('click', () => {
       const mode = modeSelect.value || 'human';
       const difficultyKey = difficultySelect.value || 'beginner';
-      const difficulty = MINESWEEPER_DIFFICULTIES.find(item => item.key === difficultyKey) || MINESWEEPER_DIFFICULTIES[0];
+    const difficulty =
+      LAND_MINE_MAPPER_DIFFICULTIES.find(item => item.key === difficultyKey) || LAND_MINE_MAPPER_DIFFICULTIES[0];
       repo.clearLeaderboard(mode, difficulty.key, difficulty.label);
       renderMinesweeperSummary(repo);
       if (window.gameAchievements) {
@@ -406,7 +407,7 @@ function setupMinesweeperManagement(repo) {
         window.gameAchievements.resetGame('minesweeper');
       }
       refreshAchievementSection({ announce: false });
-      setMessage('All minesweeper leaderboards cleared.', 'warning');
+      setMessage('All Land Mine Mapper leaderboards cleared.', 'warning');
     });
   }
 }
@@ -612,14 +613,35 @@ function writeCookie(name, value, days = 365) {
   document.cookie = `${name}=${encodeURIComponent(value)};max-age=${maxAge};path=/;SameSite=Lax`;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  const repo = new ScoreRepository();
-  renderMinesweeperSummary(repo);
-  renderWordJumbleSummary();
-  renderBasketballSummary();
-  refreshAchievementSection({ announce: false });
-  setupGlobalManagement(repo);
-  setupMinesweeperManagement(repo);
-  setupWordJumbleManagement();
-  setupBasketballManagement();
-});
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    const repo = new ScoreRepository();
+    renderMinesweeperSummary(repo);
+    renderWordJumbleSummary();
+    renderBasketballSummary();
+    refreshAchievementSection({ announce: false });
+    setupGlobalManagement(repo);
+    setupMinesweeperManagement(repo);
+    setupWordJumbleManagement();
+    setupBasketballManagement();
+  });
+}
+
+export {
+  LAND_MINE_MAPPER_DIFFICULTIES,
+  renderMinesweeperSummary,
+  renderWordJumbleSummary,
+  renderBasketballSummary,
+  normalizeWordJumbleEntries,
+  normalizeBasketballEntries,
+  normalizeBasketballEntry,
+  collectAllGameData,
+  applyImportedData,
+  setupGlobalManagement,
+  setupMinesweeperManagement,
+  setupWordJumbleManagement,
+  setupBasketballManagement,
+  refreshAchievementSection,
+  readCookie,
+  writeCookie,
+};

--- a/projects/index.html
+++ b/projects/index.html
@@ -6,14 +6,11 @@ permalink: /projects/
 <div class="achievements-page">
   <nav class="achievements-nav" aria-label="Game navigation">
     <a class="achievements-nav__link" href="{{ '/' | relative_url }}">&larr; Back to home</a>
-    <a class="achievements-nav__link" href="{{ '/projects/minesweeper/' | relative_url }}">Play Minesweeper</a>
-    <a class="achievements-nav__link" href="{{ '/projects/word-jumble/' | relative_url }}">Play Word Jumble</a>
-    <a class="achievements-nav__link" href="{{ '/projects/basketball/' | relative_url }}">Play Rapid Fire Free Throws</a>
   </nav>
 
   <header class="achievements-hero">
     <div class="achievements-hero__art">
-      <img src="{{ '/projects/minesweeper/flag.png' | relative_url }}" alt="Minesweeper flag icon" width="64" height="64" />
+      <img src="{{ '/projects/minesweeper/flag.png' | relative_url }}" alt="Land Mine Mapper flag icon" width="64" height="64" />
       <img src="{{ '/projects/word-jumble/assets/letters_small.png' | relative_url }}" alt="Word jumble tiles" width="64" height="64" />
       <img src="{{ '/projects/basketball/assets/player.png' | relative_url }}" alt="Basketball player icon" width="64" height="64" />
     </div>
@@ -27,10 +24,12 @@ permalink: /projects/
     <article class="achievement-card" data-game="minesweeper">
       <header class="achievement-card__header">
         <div class="achievement-card__icon">
-          <img src="{{ '/projects/minesweeper/smile.png' | relative_url }}" alt="Cheery minesweeper face" width="72" height="72" />
+          <img src="{{ '/projects/minesweeper/smile.png' | relative_url }}" alt="Cheery Land Mine Mapper face" width="72" height="72" />
         </div>
         <div>
-          <h2>Minesweeper Triumphs</h2>
+          <h2>
+            <a class="achievement-card__title-link" href="{{ '/projects/minesweeper/' | relative_url }}">Land Mine Mapper Triumphs</a>
+          </h2>
           <p class="achievement-card__lead">Fastest human clear times per difficulty.</p>
         </div>
       </header>
@@ -53,7 +52,9 @@ permalink: /projects/
           <img src="{{ '/projects/word-jumble/assets/letters.png' | relative_url }}" alt="Exploding power letters" width="72" height="72" />
         </div>
         <div>
-          <h2>Word Jumble Power Plays</h2>
+          <h2>
+            <a class="achievement-card__title-link" href="{{ '/projects/word-jumble/' | relative_url }}">Word Jumble Power Plays</a>
+          </h2>
           <p class="achievement-card__lead">Your mightiest anagram hauls.</p>
         </div>
       </header>
@@ -67,7 +68,9 @@ permalink: /projects/
           <img src="{{ '/projects/basketball/assets/player.png' | relative_url }}" alt="Rapid fire shooter" width="72" height="72" />
         </div>
         <div>
-          <h2>Rapid Fire Records</h2>
+          <h2>
+            <a class="achievement-card__title-link" href="{{ '/projects/basketball/' | relative_url }}">Rapid Fire Records</a>
+          </h2>
           <p class="achievement-card__lead">Top scores from the free throw cannon.</p>
         </div>
       </header>
@@ -115,7 +118,7 @@ permalink: /projects/
     </div>
 
     <div class="management-card" data-manage="minesweeper">
-      <h3>Minesweeper Leaderboards</h3>
+      <h3>Land Mine Mapper Leaderboards</h3>
       <div class="management-card__grid">
         <label>
           Mode

--- a/tests/games/land-mine-mapper/achievements.test.js
+++ b/tests/games/land-mine-mapper/achievements.test.js
@@ -1,0 +1,209 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeWordJumbleEntries,
+  normalizeBasketballEntries,
+  normalizeBasketballEntry,
+  collectAllGameData,
+  applyImportedData,
+} from '../../../projects/achievements.js';
+import { ScoreRepository } from '../../../projects/minesweeper/scripts/scoreboard.js';
+
+class MemoryStorage {
+  constructor() {
+    this.store = new Map();
+  }
+
+  getItem(key) {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.store.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.store.delete(key);
+  }
+}
+
+test('normalizeWordJumbleEntries keeps valid scores sorted by strength', () => {
+  const entries = [
+    { word: 'Galaxy', count: 11, updatedAt: '2024-03-01T12:00:00.000Z' },
+    { word: 'asteroid', count: 11, updatedAt: '2024-02-01T12:00:00.000Z' },
+    { word: '  ', count: 99 },
+    { word: 'orbit', count: '7', updatedAt: '2024-01-01T12:00:00.000Z' },
+    { word: 'probe', count: -3 },
+    { word: 'lander', count: 3, updatedAt: '' },
+  ];
+
+  const normalized = normalizeWordJumbleEntries(entries);
+
+  assert.equal(normalized.length, 5);
+  assert.deepEqual(
+    normalized.map(item => item.word),
+    ['galaxy', 'asteroid', 'orbit', 'lander', 'probe'],
+  );
+  assert.equal(normalized[0].count, 11);
+  assert.ok(normalized[0].updatedAt > normalized[1].updatedAt);
+  assert.equal(normalized.at(-1).count, 0);
+});
+
+test('normalizeBasketballEntries filters invalid data and sorts by score then recency', () => {
+  const entries = [
+    { score: 12, timestamp: '2024-03-01T10:00:00.000Z' },
+    { score: '8', timestamp: '2024-04-01T08:00:00.000Z' },
+    { score: 12, timestamp: 'invalid-date' },
+    { score: 'nan', timestamp: '2024-01-01T00:00:00.000Z' },
+  ];
+
+  const normalized = normalizeBasketballEntries(entries);
+
+  assert.equal(normalized.length, 3);
+  assert.equal(normalized[0].score, 12);
+  assert.equal(normalized[1].score, 12);
+  assert.ok(normalized[0].timestamp >= normalized[1].timestamp);
+  assert.equal(normalized[2].score, 8);
+});
+
+test('normalizeBasketballEntry enforces numeric scores and ISO timestamps', () => {
+  const cleaned = normalizeBasketballEntry({ score: '21.9', timestamp: '2024-05-01T01:02:03.000Z' });
+  assert.deepEqual(cleaned, { score: 21, timestamp: '2024-05-01T01:02:03.000Z' });
+
+  assert.equal(normalizeBasketballEntry({ score: 'oops' }), null);
+  assert.equal(
+    normalizeBasketballEntry({ score: 5, timestamp: 123 }),
+    null,
+  );
+});
+
+test('collectAllGameData captures cross-game progress in a portable payload', () => {
+  const repo = new ScoreRepository(new MemoryStorage(), 'lm_scores');
+  repo.recordWin('human', 'beginner', 'Beginner', 42, 'Scout');
+  repo.recordLoss('auto', 'beginner', 'Beginner', 'Solver');
+
+  const wordStorage = new MemoryStorage();
+  wordStorage.setItem('word_jumble_power_stats_v1', JSON.stringify([
+    { word: 'nebula', display: 'Nebula', count: 6, updatedAt: '2024-02-01T00:00:00.000Z' },
+  ]));
+
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  globalThis.window = { localStorage: wordStorage };
+  const cookieJar = { value: '' };
+  globalThis.document = {
+    getElementById: () => null,
+  };
+  Object.defineProperty(globalThis.document, 'cookie', {
+    configurable: true,
+    get() {
+      return cookieJar.value;
+    },
+    set(value) {
+      cookieJar.value = cookieJar.value ? `${cookieJar.value}; ${value}` : value;
+    },
+  });
+
+  globalThis.document.cookie = `rapid_fire_runs_level1_v1=${encodeURIComponent(
+    JSON.stringify([{ score: 13, timestamp: '2024-03-01T10:00:00.000Z' }]),
+  )}`;
+
+  const payload = collectAllGameData(repo);
+
+  assert.equal(payload.games.wordJumble.length, 1);
+  assert.equal(payload.games.basketball.level1.length, 1);
+  assert.ok(payload.games.minesweeper);
+  assert.equal(payload.games.minesweeper.human.beginner.entries.length, 1);
+
+  if (previousWindow === undefined) {
+    delete globalThis.window;
+  } else {
+    globalThis.window = previousWindow;
+  }
+  if (previousDocument === undefined) {
+    delete globalThis.document;
+  } else {
+    globalThis.document = previousDocument;
+  }
+});
+
+test('applyImportedData hydrates leaderboards and client storage', () => {
+  const repo = new ScoreRepository(new MemoryStorage(), 'lm_scores');
+
+  const wordStorage = new MemoryStorage();
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  globalThis.window = { localStorage: wordStorage };
+  const cookieJar = { value: '' };
+  globalThis.document = {
+    getElementById: () => null,
+  };
+  Object.defineProperty(globalThis.document, 'cookie', {
+    configurable: true,
+    get() {
+      return cookieJar.value;
+    },
+    set(value) {
+      cookieJar.value = cookieJar.value ? `${cookieJar.value}; ${value}` : value;
+    },
+  });
+
+  const importData = {
+    games: {
+      minesweeper: {
+        version: 4,
+        human: {
+          beginner: {
+            label: 'Beginner',
+            wins: 1,
+            losses: 0,
+            entries: [
+              { seconds: 33, recordedAt: '2024-02-02T00:00:00.000Z', name: 'Scout' },
+            ],
+          },
+        },
+        auto: {},
+        players: {
+          human: {
+            scout: {
+              name: 'Scout',
+              difficulties: { beginner: { wins: 1, losses: 0 } },
+            },
+          },
+          auto: {},
+        },
+      },
+      wordJumble: [
+        { word: 'galaxy', display: 'Galaxy', count: 12, updatedAt: '2024-03-01T00:00:00.000Z' },
+      ],
+      basketball: {
+        level1: [
+          { score: 19, timestamp: '2024-03-05T12:00:00.000Z' },
+        ],
+      },
+    },
+  };
+
+  applyImportedData(repo, importData);
+
+  const leaderboard = repo.getLeaderboard('human', 'beginner', 'Beginner');
+  assert.equal(leaderboard.wins, 1);
+  assert.equal(leaderboard.entries[0].seconds, 33);
+
+  const savedWordData = JSON.parse(wordStorage.getItem('word_jumble_power_stats_v1'));
+  assert.equal(savedWordData.length, 1);
+
+  assert.ok(globalThis.document.cookie.includes('rapid_fire_runs_level1_v1'));
+
+  if (previousWindow === undefined) {
+    delete globalThis.window;
+  } else {
+    globalThis.window = previousWindow;
+  }
+  if (previousDocument === undefined) {
+    delete globalThis.document;
+  } else {
+    globalThis.document = previousDocument;
+  }
+});


### PR DESCRIPTION
## Summary
- rebrand the achievements hub navigation so the game tiles link directly to each experience and update copy to call the puzzle Land Mine Mapper
- restyle the home page profile links as pill buttons, remove the duplicate hero heading, and drop the placeholder links section
- expose achievement utilities for testing, add a Land Mine Mapper achievements test suite, and bump the CI workflow to the latest Node actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df37ea6e788322b121ae22f1dc4423