### PR TITLE
Remove incorrect level 3 hint from level 1 page

### DIFF
--- a/projects/basketball/common.js
+++ b/projects/basketball/common.js
@@ -32,6 +32,11 @@
     const scoreFlash = config.scoreFlashId ? doc.getElementById(config.scoreFlashId) : doc.getElementById('score-flash');
     const level2Link = config.level2LinkId ? doc.getElementById(config.level2LinkId) : null;
     const level2LockText = config.level2LockTextId ? doc.getElementById(config.level2LockTextId) : null;
+    const levelRequirement = config.levelRequirementId ? doc.getElementById(config.levelRequirementId) : null;
+    const requirementLockedText =
+      typeof config.requirementLockedText === 'string' ? config.requirementLockedText : null;
+    const requirementUnlockedText =
+      typeof config.requirementUnlockedText === 'string' ? config.requirementUnlockedText : null;
     const lockBanner = config.lockBannerId ? doc.getElementById(config.lockBannerId) : null;
     const winConfig = config.win || null;
     const winLink = winConfig && winConfig.linkId ? doc.getElementById(winConfig.linkId) : null;
@@ -796,6 +801,8 @@
           : lockedText.replace('{threshold}', String(unlockThreshold)).replace('${threshold}', String(unlockThreshold));
       }
 
+      updateRequirementMessage(unlocked, bestScore);
+
       if (lockBanner) {
         lockBanner.hidden = unlocked;
       }
@@ -828,6 +835,26 @@
       }
 
       return unlocked;
+    }
+
+    function updateRequirementMessage(unlocked, bestScore) {
+      if (!levelRequirement) {
+        return;
+      }
+
+      const hasBestScore = Number.isFinite(bestScore) && bestScore > -Infinity;
+      const bestScoreDisplay = hasBestScore ? Math.round(bestScore) : '—';
+      const values = {
+        threshold: unlockThreshold,
+        bestScore: bestScoreDisplay
+      };
+
+      const template = unlocked
+        ? requirementUnlockedText || config.unlockUnlockedText || 'Next challenge unlocked! Best score: {bestScore}.'
+        : requirementLockedText ||
+          'Score {threshold}+ to unlock the next challenge. Your best score: {bestScore}.';
+
+      levelRequirement.textContent = formatTemplate(template, values);
     }
 
     function updateAdditionalLocks(latestScore = null) {
@@ -961,6 +988,20 @@
       }
 
       return unlocked;
+    }
+
+    function formatTemplate(template, replacements) {
+      if (typeof template !== 'string' || !template) {
+        return '';
+      }
+
+      return template.replace(/\{(\w+)\}|\$\{(\w+)\}/g, (match, key1, key2) => {
+        const key = key1 || key2;
+        if (Object.prototype.hasOwnProperty.call(replacements, key)) {
+          return String(replacements[key]);
+        }
+        return match;
+      });
     }
 
     function applyBlackHoleForce(ball, dt) {

--- a/projects/basketball/common.js
+++ b/projects/basketball/common.js
@@ -794,11 +794,17 @@
       }
 
       if (level2LockText) {
-        const lockedText = config.unlockLockedText || `Score ${unlockThreshold}+ on Level 1 to unlock.`;
-        const unlockedText = config.unlockUnlockedText || 'Level 2 unlocked!';
-        level2LockText.textContent = unlocked
+        const defaultLockedText = `Score ${unlockThreshold}+ on Level 1 to unlock.`;
+        const lockedTemplate =
+          typeof config.unlockLockedText === 'string' ? config.unlockLockedText : defaultLockedText;
+        const unlockedText =
+          typeof config.unlockUnlockedText === 'string' ? config.unlockUnlockedText : 'Level 2 unlocked!';
+        const message = unlocked
           ? unlockedText
-          : lockedText.replace('{threshold}', String(unlockThreshold)).replace('${threshold}', String(unlockThreshold));
+          : formatTemplate(lockedTemplate, { threshold: unlockThreshold });
+
+        level2LockText.textContent = message;
+        level2LockText.hidden = !message || !message.trim().length;
       }
 
       updateRequirementMessage(unlocked, bestScore);
@@ -849,10 +855,19 @@
         bestScore: bestScoreDisplay
       };
 
-      const template = unlocked
-        ? requirementUnlockedText || config.unlockUnlockedText || 'Next challenge unlocked! Best score: {bestScore}.'
-        : requirementLockedText ||
-          'Score {threshold}+ to unlock the next challenge. Your best score: {bestScore}.';
+      const unlockedTemplate =
+        requirementUnlockedText !== null
+          ? requirementUnlockedText
+          : (typeof config.unlockUnlockedText === 'string' && config.unlockUnlockedText.trim().length > 0
+              ? config.unlockUnlockedText
+              : 'Next challenge unlocked! Best score: {bestScore}.');
+
+      const lockedTemplate =
+        requirementLockedText !== null
+          ? requirementLockedText
+          : 'Score {threshold}+ to unlock the next challenge. Your best score: {bestScore}.';
+
+      const template = unlocked ? unlockedTemplate : lockedTemplate;
 
       levelRequirement.textContent = formatTemplate(template, values);
     }
@@ -899,12 +914,16 @@
         }
 
         if (lock.lockText) {
-          const lockedText = lock.lockedText || `Score ${lock.threshold}+ to unlock.`;
-          const unlockedText = lock.unlockedText || 'Unlocked!';
+          const defaultLockedText = `Score ${lock.threshold}+ to unlock.`;
+          const lockedTemplate =
+            typeof lock.lockedText === 'string' ? lock.lockedText : defaultLockedText;
+          const unlockedText = typeof lock.unlockedText === 'string' ? lock.unlockedText : 'Unlocked!';
           const message = unlocked
             ? unlockedText
-            : lockedText.replace('{threshold}', String(lock.threshold)).replace('${threshold}', String(lock.threshold));
+            : formatTemplate(lockedTemplate, { threshold: lock.threshold });
+
           lock.lockText.textContent = message;
+          lock.lockText.hidden = !message || !message.trim().length;
         }
 
         if (typeof lock.onUnlockStateChange === 'function') {

--- a/projects/basketball/index.html
+++ b/projects/basketball/index.html
@@ -357,7 +357,6 @@
         Win!
       </a>
       <span id="level2-lock-text" class="level-lock-text">Score 70+ on Level 1 to unlock Level 2.</span>
-      <span id="level3-lock-text" class="level-lock-text">Score 40+ on Level 2 to unlock Level 3.</span>
     </nav>
     <p class="level-requirement">Score 70 or more on Level 1 to unlock Level 2.</p>
     <div

--- a/projects/basketball/index.html
+++ b/projects/basketball/index.html
@@ -356,9 +356,11 @@
       >
         Win!
       </a>
-      <span id="level2-lock-text" class="level-lock-text">Score 70+ on Level 1 to unlock Level 2.</span>
+      <span id="level2-lock-text" class="level-lock-text">Level 2 locked — score 70+ on Level 1 to unlock it.</span>
     </nav>
-    <p class="level-requirement">Score 70 or more on Level 1 to unlock Level 2.</p>
+    <p id="level2-requirement" class="level-requirement">
+      Score 70 or more on Level 1 to unlock Level 2. Your best score: —.
+    </p>
     <div
       id="level2-unlock-toast"
       class="level-up-toast"
@@ -422,10 +424,14 @@
       historyCookie: 'rapid_fire_runs_level1_v1',
       levelKey: 'level1',
       unlockThreshold: 70,
-      unlockLockedText: 'Score 70+ on Level 1 to unlock Level 2.',
+      unlockLockedText: 'Level 2 locked — score {threshold}+ on Level 1 to unlock it.',
       unlockUnlockedText: 'Level 2 unlocked! Enter the singularity.',
       level2LinkId: 'level2-link',
       level2LockTextId: 'level2-lock-text',
+      levelRequirementId: 'level2-requirement',
+      requirementLockedText:
+        'Score {threshold} or more on Level 1 to unlock Level 2. Your best score: {bestScore}.',
+      requirementUnlockedText: 'Level 2 unlocked! Your best Level 1 score: {bestScore}.',
       scoreFlashId: 'score-flash',
       win: {
         threshold: 175,

--- a/projects/basketball/level2.html
+++ b/projects/basketball/level2.html
@@ -446,7 +446,7 @@
       levelKey: 'level2',
       unlockThreshold: 70,
       unlockLockedText: 'Reach 70+ on Level 1 to unlock the Event Horizon.',
-      unlockUnlockedText: 'Level 2 unlocked! Ride the gravity well.',
+      unlockUnlockedText: '',
       level2LockTextId: 'level2-lock-text',
       lockBannerId: 'level2-locked-message',
       scoreFlashId: 'score-flash',

--- a/projects/basketball/level3.html
+++ b/projects/basketball/level3.html
@@ -424,7 +424,7 @@
       levelKey: 'level3',
       unlockThreshold: 40,
       unlockLockedText: 'Score 40+ on Level 2 to unlock this level.',
-      unlockUnlockedText: 'Level 3 unlocked! Command the roaming board.',
+      unlockUnlockedText: '',
       level2LockTextId: 'level3-lock-text',
       lockBannerId: 'level3-locked-message',
       scoreFlashId: 'score-flash',


### PR DESCRIPTION
## Summary
- remove the level 3 lock message from the level 1 navigation to avoid showing the wrong requirement after clearing the leaderboard

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68e51e8aded88322b5999308cb6c4126