### PR TITLE
Fix Castle Ledger description markup on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,9 @@ layout: default
         <span class="home-game-icon home-game-icon--crest" aria-hidden="true">🛡️</span>
         <div class="home-game-meta">
           <a href="{{ '/projects/castle-ledger/' | relative_url }}">Castle Ledger Chronicle</a>
-          <p class="home-game-description">Trace the keep’s walls, barter for supplies, and keep the clerk’s ledger up to date.</p>
+          <p class="home-game-description">
+            Trace the keep’s walls, barter for supplies, and keep the clerk’s ledger up to date.
+          </p>
         </div>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- correct the Castle Ledger game description paragraph markup on the home page so the closing tag no longer appears in the rendered text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e72d20d0f88322b771ef4b2ef47e3e